### PR TITLE
(MODULES-6362) Change acceptance tests to execute_manifest

### DIFF
--- a/spec/acceptance/should_create_task_spec.rb
+++ b/spec/acceptance/should_create_task_spec.rb
@@ -32,10 +32,10 @@ describe "Should create a scheduled task", :node => host do
       provider    => 'taskscheduler_api2'
     }
     MANIFEST
-    execute_manifest_on(host, pp, :catch_failures => true)
+    execute_manifest(pp, :catch_failures => true)
 
     # Ensure it's idempotent
-    execute_manifest_on(host, pp, :catch_changes  => true)
+    execute_manifest(pp, :catch_changes  => true)
 
     # Verify the task exists
     query_cmd = "schtasks.exe /query /v /fo list /tn #{@taskname}"

--- a/spec/acceptance/should_destroy_spec.rb
+++ b/spec/acceptance/should_destroy_spec.rb
@@ -20,7 +20,7 @@ describe "Should destroy a scheduled task", :node => host do
       provider => 'taskscheduler_api2'
     }
     MANIFEST
-    execute_manifest_on(host, pp, :catch_failures => true)
+    execute_manifest(pp, :catch_failures => true)
   end
 
   it 'Should destroy the task' do
@@ -35,7 +35,7 @@ describe "Should destroy a scheduled task", :node => host do
     }
     MANIFEST
 
-    execute_manifest_on(host, pp, :catch_failures => true)
+    execute_manifest(pp, :catch_failures => true)
 
     query_cmd = "schtasks.exe /query /v /fo list /tn #{@taskname}"
     query_out = on(host, query_cmd, :accept_all_exit_codes => true).output


### PR DESCRIPTION
Previously in the acceptance tests the beaker method execute_manifest_on was
used however the test mode switcher gem does not support using this method in
agent only test mode.  This means we need to use the less explicit
execute_manifest method.  Fortunately our spec tests already only run on the
default node so there is no nett difference but it's still a little confusing
for new people.