### PR TITLE
(MODULES-6362) Update tests for Server 2016 Core

### DIFF
--- a/spec/acceptance/should_create_task_spec.rb
+++ b/spec/acceptance/should_create_task_spec.rb
@@ -12,7 +12,7 @@ describe "Should create a scheduled task", :node => host do
     on(host, "schtasks.exe /delete /tn #{@taskname} /f", :accept_all_exit_codes => true) do |r|
       # Empty means deletion was ok.  The 'The system cannot find the file specified' error occurs
       # if the task does not exist
-      unless r.stderr.empty? || r.stderr =~ /ERROR: The system cannot find the file specified/
+      unless r.stderr.empty? || r.stderr =~ /ERROR: The system cannot find the .+ specified/
         raise r.stderr
       end
     end

--- a/spec/acceptance/should_destroy_spec.rb
+++ b/spec/acceptance/should_destroy_spec.rb
@@ -39,6 +39,6 @@ describe "Should destroy a scheduled task", :node => host do
 
     query_cmd = "schtasks.exe /query /v /fo list /tn #{@taskname}"
     query_out = on(host, query_cmd, :accept_all_exit_codes => true).output
-    expect(query_out).to eq("ERROR: The system cannot find the file specified.\n\n")
+    expect(query_out).to match(/ERROR: The system cannot find the .+ specified/)
   end
 end


### PR DESCRIPTION
Windows Server 2016 core outputs a different error message from schtask.exe.
This caused the acceptance tests to file as the regex mathcers were too
specific.  This commit modifies the regex to be more leniant on the error
message checking.