### PR TITLE
Fix metadata which points to iis

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "summary": "Manage scheduled tasks for Windows Server 2008 and newer operating systems.",
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-scheduled_task.git",
-  "project_page": "https://github.com/puppetlabs/puppetlabs-iis",
+  "project_page": "https://github.com/puppetlabs/puppetlabs-scheduled_task",
   "issues_url": "https://tickets.puppet.com/browse/MODULES",
   "dependencies": [
 


### PR DESCRIPTION
Currently the puppetforge has the 'Project URL' link which is pointing to the puppetlabs-iis module.  This fixes that :D.