### PR TITLE
(MODULES-6843) Refactor Trigger code from V1 -> V2 adapter class

### DIFF
--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -262,29 +262,6 @@ module TaskScheduler2
 
   # Helpers
 
-  # From https://msdn.microsoft.com/en-us/library/windows/desktop/aa381850(v=vs.85).aspx
-  # https://en.wikipedia.org/wiki/ISO_8601#Durations
-  #
-  # The format for this string is PnYnMnDTnHnMnS, where nY is the number of years, nM is the number of months,
-  # nD is the number of days, 'T' is the date/time separator, nH is the number of hours, nM is the number of minutes,
-  # and nS is the number of seconds (for example, PT5M specifies 5 minutes and P1M4DT2H5M specifies one month,
-  # four days, two hours, and five minutes)
-  def self.duration_to_hash(duration)
-    regex = /^P((?'year'\d+)Y)?((?'month'\d+)M)?((?'day'\d+)D)?(T((?'hour'\d+)H)?((?'minute'\d+)M)?((?'second'\d+)S)?)?$/
-
-    matches = regex.match(duration)
-    return nil if matches.nil?
-
-    {
-      :year => matches['year'],
-      :month => matches['month'],
-      :day => matches['day'],
-      :minute => matches['minute'],
-      :hour => matches['hour'],
-      :second => matches['second'],
-    }
-  end
-
   # Converts a hash table describing year, month, day etc. into a timelimit string as per
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa381850(v=vs.85).aspx
   # https://en.wikipedia.org/wiki/ISO_8601#Durations

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -248,10 +248,6 @@ module TaskScheduler2
     result
   end
 
-  def self.append_new_trigger(definition, trigger_type)
-    definition.Triggers.create(trigger_type)
-  end
-
   # Deletes the trigger at the specified index.
   #
   def self.delete_trigger(definition, index)

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -260,25 +260,6 @@ module TaskScheduler2
     index
   end
 
-  # Helpers
-
-  # Converts a hash table describing year, month, day etc. into a timelimit string as per
-  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa381850(v=vs.85).aspx
-  # https://en.wikipedia.org/wiki/ISO_8601#Durations
-  # returns PT0S if there is nothing set.
-  def self.hash_to_duration(hash)
-    duration = 'P'
-    duration += hash[:year].to_s + 'Y' unless hash[:year].nil? || hash[:year].zero?
-    duration += hash[:month].to_s + 'M' unless hash[:month].nil? || hash[:month].zero?
-    duration += hash[:day].to_s + 'D' unless hash[:day].nil? || hash[:day].zero?
-    duration += 'T'
-    duration += hash[:hour].to_s + 'H' unless hash[:hour].nil? || hash[:hour].zero?
-    duration += hash[:minute].to_s + 'M' unless hash[:minute].nil? || hash[:minute].zero?
-    duration += hash[:second].to_s + 'S' unless hash[:second].nil? || hash[:second].zero?
-
-    duration == 'PT' ? 'PT0S' : duration
-  end
-
   # Private methods
   def self.task_service
     if @service_object.nil?

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -30,19 +30,6 @@ module TaskScheduler2
   TASK_COMPATIBILITY_V1 = 1
   TASK_COMPATIBILITY_V2 = 2
 
-  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383915%28v=vs.85%29.aspx
-  TASK_TRIGGER_EVENT                 = 0
-  TASK_TRIGGER_TIME                  = 1
-  TASK_TRIGGER_DAILY                 = 2
-  TASK_TRIGGER_WEEKLY                = 3
-  TASK_TRIGGER_MONTHLY               = 4
-  TASK_TRIGGER_MONTHLYDOW            = 5
-  TASK_TRIGGER_IDLE                  = 6
-  TASK_TRIGGER_REGISTRATION          = 7
-  TASK_TRIGGER_BOOT                  = 8
-  TASK_TRIGGER_LOGON                 = 9
-  TASK_TRIGGER_SESSION_STATE_CHANGE  = 11
-
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382538%28v=vs.85%29.aspx
   TASK_VALIDATE_ONLY                 = 0x1
   TASK_CREATE                        = 0x2

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -263,14 +263,14 @@ class TaskScheduler2V1Task
     case v1trigger['trigger_type']
       when :TASK_TIME_TRIGGER_DAILY
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa446858(v=vs.85).aspx
-        trigger_object = @tasksched.append_new_trigger(@definition, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_DAILY)
+        trigger_object = @definition.Triggers.Create(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_DAILY)
         trigger_object.DaysInterval = trigger_settings['days_interval']
         # Static V2 settings which are not set by the Puppet scheduledtask type
         trigger_object.Randomdelay = 0
 
       when :TASK_TIME_TRIGGER_WEEKLY
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa384019(v=vs.85).aspx
-        trigger_object = @tasksched.append_new_trigger(@definition, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_WEEKLY)
+        trigger_object = @definition.Triggers.Create(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_WEEKLY)
         trigger_object.DaysOfWeek = trigger_settings['days_of_week']
         trigger_object.WeeksInterval = trigger_settings['weeks_interval']
         # Static V2 settings which are not set by the Puppet scheduledtask type
@@ -278,7 +278,7 @@ class TaskScheduler2V1Task
 
       when :TASK_TIME_TRIGGER_MONTHLYDATE
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382062(v=vs.85).aspx
-        trigger_object = @tasksched.append_new_trigger(@definition, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_MONTHLY)
+        trigger_object = @definition.Triggers.Create(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_MONTHLY)
         trigger_object.DaysOfMonth = trigger_settings['days']
         trigger_object.Monthsofyear = trigger_settings['months']
         # Static V2 settings which are not set by the Puppet scheduledtask type
@@ -287,7 +287,7 @@ class TaskScheduler2V1Task
 
       when :TASK_TIME_TRIGGER_MONTHLYDOW
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382055(v=vs.85).aspx
-        trigger_object = @tasksched.append_new_trigger(@definition, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_MONTHLYDOW)
+        trigger_object = @definition.Triggers.Create(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_MONTHLYDOW)
         trigger_object.DaysOfWeek = trigger_settings['days_of_week']
         trigger_object.Monthsofyear = trigger_settings['months']
         trigger_object.Weeksofmonth = trigger_settings['weeks']
@@ -297,7 +297,7 @@ class TaskScheduler2V1Task
 
       when :TASK_TIME_TRIGGER_ONCE
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383622(v=vs.85).aspx
-        trigger_object = @tasksched.append_new_trigger(@definition, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_TIME)
+        trigger_object = @definition.Triggers.Create(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_TIME)
         # Static V2 settings which are not set by the Puppet scheduledtask type
         trigger_object.Randomdelay = 0
       else

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -254,41 +254,8 @@ class TaskScheduler2V1Task
     action
   end
 
-  # Private method that validates keys, and converts all keys to lowercase
-  # strings.
-  #
-  def transform_and_validate(hash)
-    new_hash = {}
-
-    hash.each do |key, value|
-      key = key.to_s.downcase
-      if key == 'type'
-        new_type_hash = {}
-        raise ArgumentError unless value.is_a?(Hash)
-        value.each{ |subkey, subvalue|
-          subkey = subkey.to_s.downcase
-          if Trigger::V1::ValidTypeKeys.include?(subkey)
-            new_type_hash[subkey] = subvalue
-          else
-            raise ArgumentError, "Invalid type key '#{subkey}'"
-          end
-        }
-        new_hash[key] = new_type_hash
-      else
-        if Trigger::V1::ValidKeys.include?(key)
-          new_hash[key] = value
-        else
-          raise ArgumentError, "Invalid key '#{key}'"
-        end
-      end
-    end
-
-    new_hash
-  end
-
   def append_trigger(v1trigger)
-    raise TypeError unless v1trigger.is_a?(Hash)
-    v1trigger = transform_and_validate(v1trigger)
+    v1trigger = Trigger::V1.transform_and_validate(v1trigger)
 
     trigger_object = nil
     trigger_settings = v1trigger['type']

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -384,14 +384,6 @@ class TaskScheduler2V1Task
     v1trigger
   end
 
-  def trigger_date_part_to_int(value, datepart)
-    return 0 if value.nil?
-    return 0 unless value.is_a?(String)
-    return 0 if value.empty?
-
-    DateTime.parse(value).strftime(datepart).to_i
-  end
-
   def v2trigger_to_v1hash(v2trigger)
     trigger_flags = 0
     trigger_flags = trigger_flags | Win32::TaskScheduler::TASK_TRIGGER_FLAG_HAS_END_DATE unless v2trigger.Endboundary.empty?
@@ -399,14 +391,14 @@ class TaskScheduler2V1Task
     trigger_flags = trigger_flags | Win32::TaskScheduler::TASK_TRIGGER_FLAG_DISABLED unless v2trigger.Enabled
 
     v1trigger = {
-      'start_year'              => trigger_date_part_to_int(v2trigger.StartBoundary, '%Y'),
-      'start_month'             => trigger_date_part_to_int(v2trigger.StartBoundary, '%m'),
-      'start_day'               => trigger_date_part_to_int(v2trigger.StartBoundary, '%d'),
-      'end_year'                => trigger_date_part_to_int(v2trigger.EndBoundary, '%Y'),
-      'end_month'               => trigger_date_part_to_int(v2trigger.EndBoundary, '%m'),
-      'end_day'                 => trigger_date_part_to_int(v2trigger.EndBoundary, '%d'),
-      'start_hour'              => trigger_date_part_to_int(v2trigger.StartBoundary, '%H'),
-      'start_minute'            => trigger_date_part_to_int(v2trigger.StartBoundary, '%M'),
+      'start_year'              => Trigger.date_part_to_int(v2trigger.StartBoundary, '%Y'),
+      'start_month'             => Trigger.date_part_to_int(v2trigger.StartBoundary, '%m'),
+      'start_day'               => Trigger.date_part_to_int(v2trigger.StartBoundary, '%d'),
+      'end_year'                => Trigger.date_part_to_int(v2trigger.EndBoundary, '%Y'),
+      'end_month'               => Trigger.date_part_to_int(v2trigger.EndBoundary, '%m'),
+      'end_day'                 => Trigger.date_part_to_int(v2trigger.EndBoundary, '%d'),
+      'start_hour'              => Trigger.date_part_to_int(v2trigger.StartBoundary, '%H'),
+      'start_minute'            => Trigger.date_part_to_int(v2trigger.StartBoundary, '%M'),
       'minutes_duration'        => Trigger::Duration.to_minutes(v2trigger.Repetition.Duration),
       'minutes_interval'        => Trigger::Duration.to_minutes(v2trigger.Repetition.Interval),
       'flags'                   => trigger_flags,

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -265,37 +265,22 @@ class TaskScheduler2V1Task
       when :TASK_TIME_TRIGGER_DAILY
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa446858(v=vs.85).aspx
         trigger_object.DaysInterval = trigger_settings['days_interval']
-        # Static V2 settings which are not set by the Puppet scheduledtask type
-        trigger_object.Randomdelay = 0
 
       when :TASK_TIME_TRIGGER_WEEKLY
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa384019(v=vs.85).aspx
         trigger_object.DaysOfWeek = trigger_settings['days_of_week']
         trigger_object.WeeksInterval = trigger_settings['weeks_interval']
-        # Static V2 settings which are not set by the Puppet scheduledtask type
-        trigger_object.Randomdelay = 0
 
       when :TASK_TIME_TRIGGER_MONTHLYDATE
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382062(v=vs.85).aspx
         trigger_object.DaysOfMonth = trigger_settings['days']
         trigger_object.Monthsofyear = trigger_settings['months']
-        # Static V2 settings which are not set by the Puppet scheduledtask type
-        trigger_object.RunOnLastDayOfMonth = false
-        trigger_object.Randomdelay = 0
 
       when :TASK_TIME_TRIGGER_MONTHLYDOW
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382055(v=vs.85).aspx
         trigger_object.DaysOfWeek = trigger_settings['days_of_week']
         trigger_object.Monthsofyear = trigger_settings['months']
         trigger_object.Weeksofmonth = trigger_settings['weeks']
-        # Static V2 settings which are not set by the Puppet scheduledtask type
-        trigger_object.RunonLastWeekOfMonth = false
-        trigger_object.Randomdelay = 0
-
-      when :TASK_TIME_TRIGGER_ONCE
-        # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383622(v=vs.85).aspx
-        # Static V2 settings which are not set by the Puppet scheduledtask type
-        trigger_object.Randomdelay = 0
     end
 
     # Values for all Trigger Types
@@ -307,8 +292,6 @@ class TaskScheduler2V1Task
                                                             v1trigger['start_hour'],
                                                             v1trigger['start_minute']
     )
-    # Static V2 settings which are not set by the Puppet scheduledtask type
-    trigger_object.Repetition.StopAtDurationEnd = false
 
     v1trigger
   end

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -167,7 +167,7 @@ class TaskScheduler2V1Task
 
     @tasksched.set_compatibility(@definition, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_V1)
 
-    append_trigger(task_trigger)
+    Trigger::V2.append_trigger(@definition, task_trigger)
 
     set_account_information('',nil)
 
@@ -203,7 +203,7 @@ class TaskScheduler2V1Task
   #
   # Note - This method name is a mis-nomer. It's actually appending a newly created trigger to the trigger collection.
   def trigger=(v1trigger)
-    append_trigger(v1trigger)
+    Trigger::V2.append_trigger(@definition, v1trigger)
   end
 
   # Returns the flags (integer) that modify the behavior of the work item. You
@@ -252,48 +252,6 @@ class TaskScheduler2V1Task
     end
 
     action
-  end
-
-  def append_trigger(v1trigger)
-    v1trigger = Trigger::V1.canonicalize_and_validate(v1trigger)
-
-    trigger_type = Trigger::V2.type_from_v1type(v1trigger['trigger_type'])
-    trigger_object = @definition.Triggers.Create(trigger_type)
-    trigger_settings = v1trigger['type']
-
-    case v1trigger['trigger_type']
-      when :TASK_TIME_TRIGGER_DAILY
-        # https://msdn.microsoft.com/en-us/library/windows/desktop/aa446858(v=vs.85).aspx
-        trigger_object.DaysInterval = trigger_settings['days_interval']
-
-      when :TASK_TIME_TRIGGER_WEEKLY
-        # https://msdn.microsoft.com/en-us/library/windows/desktop/aa384019(v=vs.85).aspx
-        trigger_object.DaysOfWeek = trigger_settings['days_of_week']
-        trigger_object.WeeksInterval = trigger_settings['weeks_interval']
-
-      when :TASK_TIME_TRIGGER_MONTHLYDATE
-        # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382062(v=vs.85).aspx
-        trigger_object.DaysOfMonth = trigger_settings['days']
-        trigger_object.Monthsofyear = trigger_settings['months']
-
-      when :TASK_TIME_TRIGGER_MONTHLYDOW
-        # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382055(v=vs.85).aspx
-        trigger_object.DaysOfWeek = trigger_settings['days_of_week']
-        trigger_object.Monthsofyear = trigger_settings['months']
-        trigger_object.Weeksofmonth = trigger_settings['weeks']
-    end
-
-    # Values for all Trigger Types
-    trigger_object.Repetition.Interval = "PT#{v1trigger['minutes_interval']}M" unless v1trigger['minutes_interval'].nil? || v1trigger['minutes_interval'].zero?
-    trigger_object.Repetition.Duration = "PT#{v1trigger['minutes_duration']}M" unless v1trigger['minutes_duration'].nil? || v1trigger['minutes_duration'].zero?
-    trigger_object.StartBoundary = Trigger.iso8601_datetime(v1trigger['start_year'],
-                                                            v1trigger['start_month'],
-                                                            v1trigger['start_day'],
-                                                            v1trigger['start_hour'],
-                                                            v1trigger['start_minute']
-    )
-
-    v1trigger
   end
 end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -196,7 +196,7 @@ class TaskScheduler2V1Task
     # The older V1 API uses a starting index of zero, wherease the V2 API uses one.
     # Need to increment by one to maintain the same behavior
     trigger_object = @tasksched.trigger(@definition, index + 1)
-    trigger_object.nil? ? nil : Trigger::V1.from_v2trigger(trigger_object)
+    trigger_object.nil? ? nil : Trigger::V1.from_iTrigger(trigger_object)
   end
 
   # Sets the trigger for the currently active task.

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -368,11 +368,11 @@ class TaskScheduler2V1Task
     # Values for all Trigger Types
     trigger_object.Repetition.Interval = "PT#{v1trigger['minutes_interval']}M" unless v1trigger['minutes_interval'].nil? || v1trigger['minutes_interval'].zero?
     trigger_object.Repetition.Duration = "PT#{v1trigger['minutes_duration']}M" unless v1trigger['minutes_duration'].nil? || v1trigger['minutes_duration'].zero?
-    trigger_object.StartBoundary = Trigger.normalize_datetime(v1trigger['start_year'],
-                                                              v1trigger['start_month'],
-                                                              v1trigger['start_day'],
-                                                              v1trigger['start_hour'],
-                                                              v1trigger['start_minute']
+    trigger_object.StartBoundary = Trigger.iso8601_datetime(v1trigger['start_year'],
+                                                            v1trigger['start_month'],
+                                                            v1trigger['start_day'],
+                                                            v1trigger['start_hour'],
+                                                            v1trigger['start_minute']
     )
     # Static V2 settings which are not set by the Puppet scheduledtask type
     trigger_object.Repetition.StopAtDurationEnd = false

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -314,10 +314,6 @@ class TaskScheduler2V1Task
     new_hash
   end
 
-  def normalize_datetime(year, month, day, hour, minute)
-    DateTime.new(year, month, day, hour, minute, 0).strftime('%FT%T')
-  end
-
   def append_trigger(v1trigger)
     raise TypeError unless v1trigger.is_a?(Hash)
     v1trigger = transform_and_validate(v1trigger)
@@ -372,11 +368,11 @@ class TaskScheduler2V1Task
     # Values for all Trigger Types
     trigger_object.Repetition.Interval = "PT#{v1trigger['minutes_interval']}M" unless v1trigger['minutes_interval'].nil? || v1trigger['minutes_interval'].zero?
     trigger_object.Repetition.Duration = "PT#{v1trigger['minutes_duration']}M" unless v1trigger['minutes_duration'].nil? || v1trigger['minutes_duration'].zero?
-    trigger_object.StartBoundary = normalize_datetime(v1trigger['start_year'],
-                                                      v1trigger['start_month'],
-                                                      v1trigger['start_day'],
-                                                      v1trigger['start_hour'],
-                                                      v1trigger['start_minute']
+    trigger_object.StartBoundary = Trigger.normalize_datetime(v1trigger['start_year'],
+                                                              v1trigger['start_month'],
+                                                              v1trigger['start_day'],
+                                                              v1trigger['start_hour'],
+                                                              v1trigger['start_minute']
     )
     # Static V2 settings which are not set by the Puppet scheduledtask type
     trigger_object.Repetition.StopAtDurationEnd = false

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -406,30 +406,6 @@ class TaskScheduler2V1Task
     value.to_i
   end
 
-  def duration_hash_to_seconds(value)
-    return 0 if value.nil?
-    time = 0
-    # Note - the Year and Month calculations are approximate
-    time = time + value[:year].to_i   * (365.2422 * 24 * 60**2).to_i unless value[:year].nil?
-    time = time + value[:month].to_i  * (365.2422 * 2 * 60**2).to_i  unless value[:month].nil?
-    time = time + value[:day].to_i    * 24 * 60**2                   unless value[:day].nil?
-    time = time + value[:hour].to_i   * 60**2                        unless value[:hour].nil?
-    time = time + value[:minute].to_i * 60                           unless value[:minute].nil?
-    time = time + value[:second].to_i                                unless value[:second].nil?
-
-    time
-  end
-
-  def trigger_duration_to_minutes(value)
-    return 0 if value.nil?
-    return 0 unless value.is_a?(String)
-    return 0 if value.empty?
-
-    duration = duration_hash_to_seconds(Trigger.duration_to_hash(value))
-
-    duration / 60
-   end
-
   def v2trigger_to_v1hash(v2trigger)
     trigger_flags = 0
     trigger_flags = trigger_flags | Win32::TaskScheduler::TASK_TRIGGER_FLAG_HAS_END_DATE unless v2trigger.Endboundary.empty?
@@ -445,8 +421,8 @@ class TaskScheduler2V1Task
       'end_day'                 => trigger_date_part_to_int(v2trigger.EndBoundary, '%d'),
       'start_hour'              => trigger_date_part_to_int(v2trigger.StartBoundary, '%H'),
       'start_minute'            => trigger_date_part_to_int(v2trigger.StartBoundary, '%M'),
-      'minutes_duration'        => trigger_duration_to_minutes(v2trigger.Repetition.Duration),
-      'minutes_interval'        => trigger_duration_to_minutes(v2trigger.Repetition.Interval),
+      'minutes_duration'        => Trigger.duration_to_minutes(v2trigger.Repetition.Duration),
+      'minutes_interval'        => Trigger.duration_to_minutes(v2trigger.Repetition.Interval),
       'flags'                   => trigger_flags,
       'random_minutes_interval' => trigger_string_to_int(v2trigger.Randomdelay)
     }

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -27,12 +27,7 @@ class TaskScheduler2V1Task
   def initialize(work_item = nil, trigger = nil)
     @tasksched = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2
 
-    if work_item
-      if trigger
-        raise TypeError unless trigger.is_a?(Hash)
-        new_work_item(work_item, trigger)
-      end
-    end
+    new_work_item(work_item, trigger) if work_item && trigger
   end
 
   # Returns an array of scheduled task names.

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -254,33 +254,6 @@ class TaskScheduler2V1Task
     action
   end
 
-  # Used for validating a trigger hash from Puppet
-  ValidTriggerKeys = [
-    'end_day',
-    'end_month',
-    'end_year',
-    'flags',
-    'minutes_duration',
-    'minutes_interval',
-    'random_minutes_interval',
-    'start_day',
-    'start_hour',
-    'start_minute',
-    'start_month',
-    'start_year',
-    'trigger_type',
-    'type'
-  ]
-
-  ValidTypeKeys = [
-      'days_interval',
-      'weeks_interval',
-      'days_of_week',
-      'months',
-      'days',
-      'weeks'
-  ]
-
   # Private method that validates keys, and converts all keys to lowercase
   # strings.
   #
@@ -294,7 +267,7 @@ class TaskScheduler2V1Task
         raise ArgumentError unless value.is_a?(Hash)
         value.each{ |subkey, subvalue|
           subkey = subkey.to_s.downcase
-          if ValidTypeKeys.include?(subkey)
+          if Trigger::V1::ValidTypeKeys.include?(subkey)
             new_type_hash[subkey] = subvalue
           else
             raise ArgumentError, "Invalid type key '#{subkey}'"
@@ -302,7 +275,7 @@ class TaskScheduler2V1Task
         }
         new_hash[key] = new_type_hash
       else
-        if ValidTriggerKeys.include?(key)
+        if Trigger::V1::ValidKeys.include?(key)
           new_hash[key] = value
         else
           raise ArgumentError, "Invalid key '#{key}'"

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -390,15 +390,18 @@ class TaskScheduler2V1Task
     # There is no corresponding setting for the V1 flag TASK_TRIGGER_FLAG_KILL_AT_DURATION_END
     trigger_flags = trigger_flags | Win32::TaskScheduler::TASK_TRIGGER_FLAG_DISABLED unless v2trigger.Enabled
 
+    start_boundary = Trigger.string_to_date(v2trigger.StartBoundary)
+    end_boundary = Trigger.string_to_date(v2trigger.EndBoundary)
+
     v1trigger = {
-      'start_year'              => Trigger.date_part_to_int(v2trigger.StartBoundary, '%Y'),
-      'start_month'             => Trigger.date_part_to_int(v2trigger.StartBoundary, '%m'),
-      'start_day'               => Trigger.date_part_to_int(v2trigger.StartBoundary, '%d'),
-      'end_year'                => Trigger.date_part_to_int(v2trigger.EndBoundary, '%Y'),
-      'end_month'               => Trigger.date_part_to_int(v2trigger.EndBoundary, '%m'),
-      'end_day'                 => Trigger.date_part_to_int(v2trigger.EndBoundary, '%d'),
-      'start_hour'              => Trigger.date_part_to_int(v2trigger.StartBoundary, '%H'),
-      'start_minute'            => Trigger.date_part_to_int(v2trigger.StartBoundary, '%M'),
+      'start_year'              => start_boundary.year,
+      'start_month'             => start_boundary.month,
+      'start_day'               => start_boundary.day,
+      'end_year'                => end_boundary ? end_boundary.year : 0,
+      'end_month'               => end_boundary ? end_boundary.month : 0,
+      'end_day'                 => end_boundary ? end_boundary.day : 0,
+      'start_hour'              => start_boundary.hour,
+      'start_minute'            => start_boundary.minute,
       'minutes_duration'        => Trigger::Duration.to_minutes(v2trigger.Repetition.Duration),
       'minutes_interval'        => Trigger::Duration.to_minutes(v2trigger.Repetition.Interval),
       'flags'                   => trigger_flags,

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -416,8 +416,8 @@ class TaskScheduler2V1Task
       'end_day'                 => trigger_date_part_to_int(v2trigger.EndBoundary, '%d'),
       'start_hour'              => trigger_date_part_to_int(v2trigger.StartBoundary, '%H'),
       'start_minute'            => trigger_date_part_to_int(v2trigger.StartBoundary, '%M'),
-      'minutes_duration'        => Trigger.duration_to_minutes(v2trigger.Repetition.Duration),
-      'minutes_interval'        => Trigger.duration_to_minutes(v2trigger.Repetition.Interval),
+      'minutes_duration'        => Trigger::Duration.to_minutes(v2trigger.Repetition.Duration),
+      'minutes_interval'        => Trigger::Duration.to_minutes(v2trigger.Repetition.Interval),
       'flags'                   => trigger_flags,
       'random_minutes_interval' => trigger_string_to_int(v2trigger.Randomdelay)
     }

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -167,7 +167,7 @@ class TaskScheduler2V1Task
 
     @tasksched.set_compatibility(@definition, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_V1)
 
-    Trigger::V2.append_trigger(@definition, task_trigger)
+    Trigger::V2.append_v1trigger(@definition, task_trigger)
 
     set_account_information('',nil)
 
@@ -203,7 +203,7 @@ class TaskScheduler2V1Task
   #
   # Note - This method name is a mis-nomer. It's actually appending a newly created trigger to the trigger collection.
   def trigger=(v1trigger)
-    Trigger::V2.append_trigger(@definition, v1trigger)
+    Trigger::V2.append_v1trigger(@definition, v1trigger)
   end
 
   # Returns the flags (integer) that modify the behavior of the work item. You

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -71,12 +71,6 @@ class TaskScheduler2V1Task
     @tasksched.delete(full_taskname)
   end
 
-  # Execute the current task.
-  #
-  def run
-    raise NotImplementedError
-  end
-
   # Saves the current task. Tasks must be saved before they can be activated.
   # The .job file itself is typically stored in the C:\WINDOWS\Tasks folder.
   #
@@ -87,19 +81,6 @@ class TaskScheduler2V1Task
     task_object = @task.nil? ? @full_task_path : @task
     @tasksched.save(task_object, @definition, @task_password)
   end
-
-  # Terminate the current task.
-  #
-  def terminate
-    raise NotImplementedError
-  end
-
-  # Set the host on which the various TaskScheduler methods will execute.
-  #
-  def machine=(host)
-    raise NotImplementedError
-  end
-  alias :host= :machine=
 
   # Sets the +user+ and +password+ for the given task. If the user and
   # password are set properly then true is returned.
@@ -177,21 +158,6 @@ class TaskScheduler2V1Task
     dir
   end
 
-  # Returns the task's priority level. Possible values are 'idle',
-  # 'normal', 'high', 'realtime', 'below_normal', 'above_normal',
-  # and 'unknown'.
-  #
-  def priority
-    raise NotImplementedError
-  end
-
-  # Sets the priority of the task. The +priority+ should be a numeric
-  # priority constant value.
-  #
-  def priority=(priority)
-    raise NotImplementedError
-  end
-
   # Creates a new work item (scheduled job) with the given +trigger+. The
   # trigger variable is a hash of options that define when the scheduled
   # job should run.
@@ -245,12 +211,6 @@ class TaskScheduler2V1Task
     append_trigger(v1trigger)
   end
 
-  # Adds a trigger at the specified index.
-  #
-  def add_trigger(index, trigger)
-    raise NotImplementedError
-  end
-
   # Returns the flags (integer) that modify the behavior of the work item. You
   # must OR the return value to determine the flags yourself.
   #
@@ -264,70 +224,6 @@ class TaskScheduler2V1Task
   #
   def flags=(flags)
     @definition.Settings.Enabled = (flags & Win32::TaskScheduler::DISABLED == 0)
-  end
-
-  # Returns the status of the currently active task. Possible values are
-  # 'ready', 'running', 'not scheduled' or 'unknown'.
-  #
-  def status
-    raise NotImplementedError
-  end
-
-  # Returns the exit code from the last scheduled run.
-  #
-  def exit_code
-    raise NotImplementedError
-  end
-
-  # Returns the comment associated with the task, if any.
-  #
-  def comment
-    raise NotImplementedError
-  end
-
-  # Sets the comment for the task.
-  #
-  def comment=(comment)
-    raise NotImplementedError
-  end
-
-  # Returns the name of the user who created the task.
-  #
-  def creator
-    raise NotImplementedError
-  end
-
-  # Sets the creator for the task.
-  #
-  def creator=(creator)
-    raise NotImplementedError
-  end
-
-  # Returns a Time object that indicates the next time the task will run.
-  #
-  def next_run_time
-    raise NotImplementedError
-  end
-
-  # Returns a Time object indicating the most recent time the task ran or
-  # nil if the task has never run.
-  #
-  def most_recent_run_time
-    raise NotImplementedError
-  end
-
-  # Returns the maximum length of time, in milliseconds, that the task
-  # will run before terminating.
-  #
-  def max_run_time
-    raise NotImplementedError
-  end
-
-  # Sets the maximum length of time, in milliseconds, that the task can run
-  # before terminating. Returns the value you specified if successful.
-  #
-  def max_run_time=(max_run_time)
-    raise NotImplementedError
   end
 
   # Returns whether or not the scheduled task exists.

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -3,6 +3,7 @@
 # will only surface the features used by the Puppet scheduledtask provider
 #
 require_relative './taskscheduler2'
+require_relative './trigger'
 require 'puppet/util/windows/taskscheduler' # Needed for the WIN32::ScheduledTask flag constants
 
 module PuppetX
@@ -424,7 +425,7 @@ class TaskScheduler2V1Task
     return 0 unless value.is_a?(String)
     return 0 if value.empty?
 
-    duration = duration_hash_to_seconds(@tasksched.duration_to_hash(value))
+    duration = duration_hash_to_seconds(Trigger.duration_to_hash(value))
 
     duration / 60
    end

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -392,15 +392,6 @@ class TaskScheduler2V1Task
     DateTime.parse(value).strftime(datepart).to_i
   end
 
-  def trigger_string_to_int(value)
-    return 0 if value.nil?
-    return value if value.is_a?(Integer)
-    return 0 unless value.is_a?(String)
-    return 0 if value.empty?
-
-    value.to_i
-  end
-
   def v2trigger_to_v1hash(v2trigger)
     trigger_flags = 0
     trigger_flags = trigger_flags | Win32::TaskScheduler::TASK_TRIGGER_FLAG_HAS_END_DATE unless v2trigger.Endboundary.empty?
@@ -419,7 +410,7 @@ class TaskScheduler2V1Task
       'minutes_duration'        => Trigger::Duration.to_minutes(v2trigger.Repetition.Duration),
       'minutes_interval'        => Trigger::Duration.to_minutes(v2trigger.Repetition.Interval),
       'flags'                   => trigger_flags,
-      'random_minutes_interval' => trigger_string_to_int(v2trigger.Randomdelay)
+      'random_minutes_interval' => Trigger.string_to_int(v2trigger.Randomdelay)
     }
 
     case v2trigger.ole_type.to_s
@@ -429,26 +420,26 @@ class TaskScheduler2V1Task
       when 'IDailyTrigger'
         v1trigger['trigger_type'] = :TASK_TIME_TRIGGER_DAILY
         v1trigger['type'] = {
-          'days_interval' => trigger_string_to_int(v2trigger.DaysInterval)
+          'days_interval' => Trigger.string_to_int(v2trigger.DaysInterval)
         }
       when 'IWeeklyTrigger'
         v1trigger['trigger_type'] = :TASK_TIME_TRIGGER_WEEKLY
         v1trigger['type'] = {
-          'weeks_interval' => trigger_string_to_int(v2trigger.WeeksInterval),
-          'days_of_week'   => trigger_string_to_int(v2trigger.DaysOfWeek)
+          'weeks_interval' => Trigger.string_to_int(v2trigger.WeeksInterval),
+          'days_of_week'   => Trigger.string_to_int(v2trigger.DaysOfWeek)
         }
       when 'IMonthlyTrigger'
         v1trigger['trigger_type'] = :TASK_TIME_TRIGGER_MONTHLYDATE
         v1trigger['type'] = {
-          'days'   => trigger_string_to_int(v2trigger.DaysOfMonth),
-          'months' => trigger_string_to_int(v2trigger.MonthsOfYear)
+          'days'   => Trigger.string_to_int(v2trigger.DaysOfMonth),
+          'months' => Trigger.string_to_int(v2trigger.MonthsOfYear)
         }
       when 'IMonthlyDOWTrigger'
         v1trigger['trigger_type'] = :TASK_TIME_TRIGGER_MONTHLYDOW
         v1trigger['type'] = {
-          'weeks'        => trigger_string_to_int(v2trigger.WeeksOfMonth),
-          'days_of_week' => trigger_string_to_int(v2trigger.DaysOfWeek),
-          'months'       => trigger_string_to_int(v2trigger.MonthsOfYear)
+          'weeks'        => Trigger.string_to_int(v2trigger.WeeksOfMonth),
+          'days_of_week' => Trigger.string_to_int(v2trigger.DaysOfWeek),
+          'months'       => Trigger.string_to_int(v2trigger.MonthsOfYear)
         }
       else
         raise Error.new(_("Unknown trigger type %{type}") % { type: v2trigger.ole_type.to_s })

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -255,7 +255,7 @@ class TaskScheduler2V1Task
   end
 
   def append_trigger(v1trigger)
-    v1trigger = Trigger::V1.transform_and_validate(v1trigger)
+    v1trigger = Trigger::V1.canonicalize_and_validate(v1trigger)
 
     trigger_object = nil
     trigger_settings = v1trigger['type']

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -257,20 +257,19 @@ class TaskScheduler2V1Task
   def append_trigger(v1trigger)
     v1trigger = Trigger::V1.canonicalize_and_validate(v1trigger)
 
-    trigger_object = nil
+    trigger_type = Trigger::V2.type_from_v1type(v1trigger['trigger_type'])
+    trigger_object = @definition.Triggers.Create(trigger_type)
     trigger_settings = v1trigger['type']
 
     case v1trigger['trigger_type']
       when :TASK_TIME_TRIGGER_DAILY
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa446858(v=vs.85).aspx
-        trigger_object = @definition.Triggers.Create(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_DAILY)
         trigger_object.DaysInterval = trigger_settings['days_interval']
         # Static V2 settings which are not set by the Puppet scheduledtask type
         trigger_object.Randomdelay = 0
 
       when :TASK_TIME_TRIGGER_WEEKLY
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa384019(v=vs.85).aspx
-        trigger_object = @definition.Triggers.Create(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_WEEKLY)
         trigger_object.DaysOfWeek = trigger_settings['days_of_week']
         trigger_object.WeeksInterval = trigger_settings['weeks_interval']
         # Static V2 settings which are not set by the Puppet scheduledtask type
@@ -278,7 +277,6 @@ class TaskScheduler2V1Task
 
       when :TASK_TIME_TRIGGER_MONTHLYDATE
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382062(v=vs.85).aspx
-        trigger_object = @definition.Triggers.Create(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_MONTHLY)
         trigger_object.DaysOfMonth = trigger_settings['days']
         trigger_object.Monthsofyear = trigger_settings['months']
         # Static V2 settings which are not set by the Puppet scheduledtask type
@@ -287,7 +285,6 @@ class TaskScheduler2V1Task
 
       when :TASK_TIME_TRIGGER_MONTHLYDOW
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382055(v=vs.85).aspx
-        trigger_object = @definition.Triggers.Create(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_MONTHLYDOW)
         trigger_object.DaysOfWeek = trigger_settings['days_of_week']
         trigger_object.Monthsofyear = trigger_settings['months']
         trigger_object.Weeksofmonth = trigger_settings['weeks']
@@ -297,11 +294,8 @@ class TaskScheduler2V1Task
 
       when :TASK_TIME_TRIGGER_ONCE
         # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383622(v=vs.85).aspx
-        trigger_object = @definition.Triggers.Create(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_TIME)
         # Static V2 settings which are not set by the Puppet scheduledtask type
         trigger_object.Randomdelay = 0
-      else
-        raise Error.new(_("Unknown V1 trigger type %{type}") % { type: v1trigger['trigger_type'] })
     end
 
     # Values for all Trigger Types

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -4,56 +4,54 @@ module PuppetLabs
 module ScheduledTask
 
 module Trigger
-  # From https://msdn.microsoft.com/en-us/library/windows/desktop/aa381850(v=vs.85).aspx
-  # https://en.wikipedia.org/wiki/ISO_8601#Durations
-  #
-  # The format for this string is PnYnMnDTnHnMnS, where nY is the number of years, nM is the number of months,
-  # nD is the number of days, 'T' is the date/time separator, nH is the number of hours, nM is the number of minutes,
-  # and nS is the number of seconds (for example, PT5M specifies 5 minutes and P1M4DT2H5M specifies one month,
-  # four days, two hours, and five minutes)
-  def duration_to_hash(duration)
-    regex = /^P((?'year'\d+)Y)?((?'month'\d+)M)?((?'day'\d+)D)?(T((?'hour'\d+)H)?((?'minute'\d+)M)?((?'second'\d+)S)?)?$/
+  class Duration
+    # From https://msdn.microsoft.com/en-us/library/windows/desktop/aa381850(v=vs.85).aspx
+    # https://en.wikipedia.org/wiki/ISO_8601#Durations
+    #
+    # The format for this string is PnYnMnDTnHnMnS, where nY is the number of years, nM is the number of months,
+    # nD is the number of days, 'T' is the date/time separator, nH is the number of hours, nM is the number of minutes,
+    # and nS is the number of seconds (for example, PT5M specifies 5 minutes and P1M4DT2H5M specifies one month,
+    # four days, two hours, and five minutes)
+    def self.to_hash(duration)
+      regex = /^P((?'year'\d+)Y)?((?'month'\d+)M)?((?'day'\d+)D)?(T((?'hour'\d+)H)?((?'minute'\d+)M)?((?'second'\d+)S)?)?$/
 
-    matches = regex.match(duration)
-    return nil if matches.nil?
+      matches = regex.match(duration)
+      return nil if matches.nil?
 
-    {
-      :year => matches['year'],
-      :month => matches['month'],
-      :day => matches['day'],
-      :minute => matches['minute'],
-      :hour => matches['hour'],
-      :second => matches['second'],
-    }
+      {
+        :year => matches['year'],
+        :month => matches['month'],
+        :day => matches['day'],
+        :minute => matches['minute'],
+        :hour => matches['hour'],
+        :second => matches['second'],
+      }
+    end
+
+    def self.hash_to_seconds(value)
+      return 0 if value.nil?
+      time = 0
+      # Note - the Year and Month calculations are approximate
+      time = time + value[:year].to_i   * (365.2422 * 24 * 60**2)      unless value[:year].nil?
+      time = time + value[:month].to_i  * (365.2422 * 2 * 60**2)       unless value[:month].nil?
+      time = time + value[:day].to_i    * 24 * 60**2                   unless value[:day].nil?
+      time = time + value[:hour].to_i   * 60**2                        unless value[:hour].nil?
+      time = time + value[:minute].to_i * 60                           unless value[:minute].nil?
+      time = time + value[:second].to_i                                unless value[:second].nil?
+
+      time.to_i
+    end
+
+    def self.to_minutes(value)
+      return 0 if value.nil?
+      return 0 unless value.is_a?(String)
+      return 0 if value.empty?
+
+      duration = hash_to_seconds(to_hash(value))
+
+      duration / 60
+    end
   end
-  module_function :duration_to_hash
-
-  def duration_hash_to_seconds(value)
-    return 0 if value.nil?
-    time = 0
-    # Note - the Year and Month calculations are approximate
-    time = time + value[:year].to_i   * (365.2422 * 24 * 60**2)      unless value[:year].nil?
-    time = time + value[:month].to_i  * (365.2422 * 2 * 60**2)       unless value[:month].nil?
-    time = time + value[:day].to_i    * 24 * 60**2                   unless value[:day].nil?
-    time = time + value[:hour].to_i   * 60**2                        unless value[:hour].nil?
-    time = time + value[:minute].to_i * 60                           unless value[:minute].nil?
-    time = time + value[:second].to_i                                unless value[:second].nil?
-
-    time.to_i
-  end
-  module_function :duration_hash_to_seconds
-
-  def duration_to_minutes(value)
-    return 0 if value.nil?
-    return 0 unless value.is_a?(String)
-    return 0 if value.empty?
-
-    duration = duration_hash_to_seconds(duration_to_hash(value))
-
-    duration / 60
-   end
-   module_function :duration_to_minutes
-
 end
 end
 end

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -218,39 +218,39 @@ module Trigger
       v1trigger = Trigger::V1.canonicalize_and_validate(v1trigger)
 
       trigger_type = type_from_v1type(v1trigger['trigger_type'])
-      trigger_object = definition.Triggers.Create(trigger_type)
+      iTrigger = definition.Triggers.Create(trigger_type)
       trigger_settings = v1trigger['type']
 
-      case v1trigger['trigger_type']
-        when :TASK_TIME_TRIGGER_DAILY
+      case trigger_type
+        when TaskScheduler2::TASK_TRIGGER_DAILY
           # https://msdn.microsoft.com/en-us/library/windows/desktop/aa446858(v=vs.85).aspx
-          trigger_object.DaysInterval = trigger_settings['days_interval']
+          iTrigger.DaysInterval = trigger_settings['days_interval']
 
-        when :TASK_TIME_TRIGGER_WEEKLY
+        when TaskScheduler2::TASK_TRIGGER_WEEKLY
           # https://msdn.microsoft.com/en-us/library/windows/desktop/aa384019(v=vs.85).aspx
-          trigger_object.DaysOfWeek = trigger_settings['days_of_week']
-          trigger_object.WeeksInterval = trigger_settings['weeks_interval']
+          iTrigger.DaysOfWeek = trigger_settings['days_of_week']
+          iTrigger.WeeksInterval = trigger_settings['weeks_interval']
 
-        when :TASK_TIME_TRIGGER_MONTHLYDATE
+        when TaskScheduler2::TASK_TRIGGER_MONTHLY
           # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382062(v=vs.85).aspx
-          trigger_object.DaysOfMonth = trigger_settings['days']
-          trigger_object.Monthsofyear = trigger_settings['months']
+          iTrigger.DaysOfMonth = trigger_settings['days']
+          iTrigger.Monthsofyear = trigger_settings['months']
 
-        when :TASK_TIME_TRIGGER_MONTHLYDOW
+        when TaskScheduler2::TASK_TRIGGER_MONTHLYDOW
           # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382055(v=vs.85).aspx
-          trigger_object.DaysOfWeek = trigger_settings['days_of_week']
-          trigger_object.Monthsofyear = trigger_settings['months']
-          trigger_object.Weeksofmonth = trigger_settings['weeks']
+          iTrigger.DaysOfWeek = trigger_settings['days_of_week']
+          iTrigger.Monthsofyear = trigger_settings['months']
+          iTrigger.Weeksofmonth = trigger_settings['weeks']
       end
 
       # Values for all Trigger Types
-      trigger_object.Repetition.Interval = "PT#{v1trigger['minutes_interval']}M" unless v1trigger['minutes_interval'].nil? || v1trigger['minutes_interval'].zero?
-      trigger_object.Repetition.Duration = "PT#{v1trigger['minutes_duration']}M" unless v1trigger['minutes_duration'].nil? || v1trigger['minutes_duration'].zero?
-      trigger_object.StartBoundary = Trigger.iso8601_datetime(v1trigger['start_year'],
-                                                              v1trigger['start_month'],
-                                                              v1trigger['start_day'],
-                                                              v1trigger['start_hour'],
-                                                              v1trigger['start_minute']
+      iTrigger.Repetition.Interval = "PT#{v1trigger['minutes_interval']}M" unless v1trigger['minutes_interval'].nil? || v1trigger['minutes_interval'].zero?
+      iTrigger.Repetition.Duration = "PT#{v1trigger['minutes_duration']}M" unless v1trigger['minutes_duration'].nil? || v1trigger['minutes_duration'].zero?
+      iTrigger.StartBoundary = Trigger.iso8601_datetime(v1trigger['start_year'],
+                                                        v1trigger['start_month'],
+                                                        v1trigger['start_day'],
+                                                        v1trigger['start_hour'],
+                                                        v1trigger['start_minute']
       )
 
       v1trigger

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -79,6 +79,33 @@ module Trigger
   # TASK_TRIGGER structure approximated as Ruby hash
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383618(v=vs.85).aspx
   class V1
+    # Used for validating a trigger hash from Puppet
+    ValidKeys = [
+      'end_day',
+      'end_month',
+      'end_year',
+      'flags',
+      'minutes_duration',
+      'minutes_interval',
+      'random_minutes_interval',
+      'start_day',
+      'start_hour',
+      'start_minute',
+      'start_month',
+      'start_year',
+      'trigger_type',
+      'type'
+    ]
+
+    ValidTypeKeys = [
+        'days_interval',
+        'weeks_interval',
+        'days_of_week',
+        'months',
+        'days',
+        'weeks'
+    ]
+
     # iTrigger is a COM ITrigger instance
     def self.from_iTrigger(iTrigger)
       require 'puppet/util/windows/taskscheduler' # Needed for the WIN32::ScheduledTask flag constants

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -200,13 +200,28 @@ module Trigger
   end
 
   class V2
+    class Type
+      # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383915%28v=vs.85%29.aspx
+      TASK_TRIGGER_EVENT                 = 0
+      TASK_TRIGGER_TIME                  = 1
+      TASK_TRIGGER_DAILY                 = 2
+      TASK_TRIGGER_WEEKLY                = 3
+      TASK_TRIGGER_MONTHLY               = 4
+      TASK_TRIGGER_MONTHLYDOW            = 5
+      TASK_TRIGGER_IDLE                  = 6
+      TASK_TRIGGER_REGISTRATION          = 7
+      TASK_TRIGGER_BOOT                  = 8
+      TASK_TRIGGER_LOGON                 = 9
+      TASK_TRIGGER_SESSION_STATE_CHANGE  = 11
+    end
+
     V1_TYPE_MAP =
     {
-      :TASK_TIME_TRIGGER_DAILY => TaskScheduler2::TASK_TRIGGER_DAILY,
-      :TASK_TIME_TRIGGER_WEEKLY => TaskScheduler2::TASK_TRIGGER_WEEKLY,
-      :TASK_TIME_TRIGGER_MONTHLYDATE => TaskScheduler2::TASK_TRIGGER_MONTHLY,
-      :TASK_TIME_TRIGGER_MONTHLYDOW => TaskScheduler2::TASK_TRIGGER_MONTHLYDOW,
-      :TASK_TIME_TRIGGER_ONCE => TaskScheduler2::TASK_TRIGGER_TIME,
+      :TASK_TIME_TRIGGER_DAILY => Type::TASK_TRIGGER_DAILY,
+      :TASK_TIME_TRIGGER_WEEKLY => Type::TASK_TRIGGER_WEEKLY,
+      :TASK_TIME_TRIGGER_MONTHLYDATE => Type::TASK_TRIGGER_MONTHLY,
+      :TASK_TIME_TRIGGER_MONTHLYDOW => Type::TASK_TRIGGER_MONTHLYDOW,
+      :TASK_TIME_TRIGGER_ONCE => Type::TASK_TRIGGER_TIME,
     }.freeze
 
     def self.type_from_v1type(v1type)
@@ -222,21 +237,21 @@ module Trigger
       trigger_settings = v1trigger['type']
 
       case trigger_type
-        when TaskScheduler2::TASK_TRIGGER_DAILY
+        when Type::TASK_TRIGGER_DAILY
           # https://msdn.microsoft.com/en-us/library/windows/desktop/aa446858(v=vs.85).aspx
           iTrigger.DaysInterval = trigger_settings['days_interval']
 
-        when TaskScheduler2::TASK_TRIGGER_WEEKLY
+        when Type::TASK_TRIGGER_WEEKLY
           # https://msdn.microsoft.com/en-us/library/windows/desktop/aa384019(v=vs.85).aspx
           iTrigger.DaysOfWeek = trigger_settings['days_of_week']
           iTrigger.WeeksInterval = trigger_settings['weeks_interval']
 
-        when TaskScheduler2::TASK_TRIGGER_MONTHLY
+        when Type::TASK_TRIGGER_MONTHLY
           # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382062(v=vs.85).aspx
           iTrigger.DaysOfMonth = trigger_settings['days']
           iTrigger.Monthsofyear = trigger_settings['months']
 
-        when TaskScheduler2::TASK_TRIGGER_MONTHLYDOW
+        when Type::TASK_TRIGGER_MONTHLYDOW
           # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382055(v=vs.85).aspx
           iTrigger.DaysOfWeek = trigger_settings['days_of_week']
           iTrigger.Monthsofyear = trigger_settings['months']

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -52,6 +52,17 @@ module Trigger
       duration / 60
     end
   end
+
+  def string_to_int(value)
+    return 0 if value.nil?
+    return value if value.is_a?(Integer)
+    return 0 unless value.is_a?(String)
+    return 0 if value.empty?
+
+    value.to_i
+  end
+  module_function :string_to_int
+
 end
 end
 end

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -71,10 +71,10 @@ module Trigger
   end
   module_function :string_to_date
 
-  def normalize_datetime(year, month, day, hour, minute)
-    DateTime.new(year, month, day, hour, minute, 0).strftime('%FT%T')
+  def iso8601_datetime(year, month, day, hour, minute)
+    DateTime.new(year, month, day, hour, minute, 0).iso8601
   end
-  module_function :normalize_datetime
+  module_function :iso8601_datetime
 
 end
 end

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -76,6 +76,71 @@ module Trigger
   end
   module_function :iso8601_datetime
 
+  # TASK_TRIGGER structure approximated as Ruby hash
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383618(v=vs.85).aspx
+  class V1
+    # v2trigger is a COM trigger instance
+    def self.from_v2trigger(v2trigger)
+      require 'puppet/util/windows/taskscheduler' # Needed for the WIN32::ScheduledTask flag constants
+
+      trigger_flags = 0
+      trigger_flags = trigger_flags | Win32::TaskScheduler::TASK_TRIGGER_FLAG_HAS_END_DATE unless v2trigger.Endboundary.empty?
+      # There is no corresponding setting for the V1 flag TASK_TRIGGER_FLAG_KILL_AT_DURATION_END
+      trigger_flags = trigger_flags | Win32::TaskScheduler::TASK_TRIGGER_FLAG_DISABLED unless v2trigger.Enabled
+
+      start_boundary = Trigger.string_to_date(v2trigger.StartBoundary)
+      end_boundary = Trigger.string_to_date(v2trigger.EndBoundary)
+
+      v1trigger = {
+        'start_year'              => start_boundary.year,
+        'start_month'             => start_boundary.month,
+        'start_day'               => start_boundary.day,
+        'end_year'                => end_boundary ? end_boundary.year : 0,
+        'end_month'               => end_boundary ? end_boundary.month : 0,
+        'end_day'                 => end_boundary ? end_boundary.day : 0,
+        'start_hour'              => start_boundary.hour,
+        'start_minute'            => start_boundary.minute,
+        'minutes_duration'        => Trigger::Duration.to_minutes(v2trigger.Repetition.Duration),
+        'minutes_interval'        => Trigger::Duration.to_minutes(v2trigger.Repetition.Interval),
+        'flags'                   => trigger_flags,
+        'random_minutes_interval' => Trigger.string_to_int(v2trigger.Randomdelay)
+      }
+
+      case v2trigger.ole_type.to_s
+        when 'ITimeTrigger'
+          v1trigger['trigger_type'] = :TASK_TIME_TRIGGER_ONCE
+          v1trigger['type'] = { 'once' => nil }
+        when 'IDailyTrigger'
+          v1trigger['trigger_type'] = :TASK_TIME_TRIGGER_DAILY
+          v1trigger['type'] = {
+            'days_interval' => Trigger.string_to_int(v2trigger.DaysInterval)
+          }
+        when 'IWeeklyTrigger'
+          v1trigger['trigger_type'] = :TASK_TIME_TRIGGER_WEEKLY
+          v1trigger['type'] = {
+            'weeks_interval' => Trigger.string_to_int(v2trigger.WeeksInterval),
+            'days_of_week'   => Trigger.string_to_int(v2trigger.DaysOfWeek)
+          }
+        when 'IMonthlyTrigger'
+          v1trigger['trigger_type'] = :TASK_TIME_TRIGGER_MONTHLYDATE
+          v1trigger['type'] = {
+            'days'   => Trigger.string_to_int(v2trigger.DaysOfMonth),
+            'months' => Trigger.string_to_int(v2trigger.MonthsOfYear)
+          }
+        when 'IMonthlyDOWTrigger'
+          v1trigger['trigger_type'] = :TASK_TIME_TRIGGER_MONTHLYDOW
+          v1trigger['type'] = {
+            'weeks'        => Trigger.string_to_int(v2trigger.WeeksOfMonth),
+            'days_of_week' => Trigger.string_to_int(v2trigger.DaysOfWeek),
+            'months'       => Trigger.string_to_int(v2trigger.MonthsOfYear)
+          }
+        else
+          raise Error.new(_("Unknown trigger type %{type}") % { type: v2trigger.ole_type.to_s })
+      end
+
+      v1trigger
+    end
+  end
 end
 end
 end

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -62,13 +62,14 @@ module Trigger
   end
   module_function :string_to_int
 
-  def date_part_to_int(value, datepart)
-    return 0 if value.nil? || value.empty?
+  def string_to_date(value)
+    return nil if value.nil?
     raise ArgumentError.new('value must be a String') unless value.is_a?(String)
+    return nil if value.empty?
 
-    DateTime.parse(value).strftime(datepart).to_i
+    DateTime.parse(value)
   end
-  module_function :date_part_to_int
+  module_function :string_to_date
 
 end
 end

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -28,6 +28,32 @@ module Trigger
   end
   module_function :duration_to_hash
 
+  def duration_hash_to_seconds(value)
+    return 0 if value.nil?
+    time = 0
+    # Note - the Year and Month calculations are approximate
+    time = time + value[:year].to_i   * (365.2422 * 24 * 60**2).to_i unless value[:year].nil?
+    time = time + value[:month].to_i  * (365.2422 * 2 * 60**2).to_i  unless value[:month].nil?
+    time = time + value[:day].to_i    * 24 * 60**2                   unless value[:day].nil?
+    time = time + value[:hour].to_i   * 60**2                        unless value[:hour].nil?
+    time = time + value[:minute].to_i * 60                           unless value[:minute].nil?
+    time = time + value[:second].to_i                                unless value[:second].nil?
+
+    time
+  end
+  module_function :duration_hash_to_seconds
+
+  def duration_to_minutes(value)
+    return 0 if value.nil?
+    return 0 unless value.is_a?(String)
+    return 0 if value.empty?
+
+    duration = duration_hash_to_seconds(duration_to_hash(value))
+
+    duration / 60
+   end
+   module_function :duration_to_minutes
+
 end
 end
 end

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -106,6 +106,39 @@ module Trigger
         'weeks'
     ]
 
+    # canonicalize given trigger hash
+    # throws errors if hash structure is invalid
+    # @returns original object with downcased keys
+    def self.transform_and_validate(hash)
+      raise TypeError unless hash.is_a?(Hash)
+      new_hash = {}
+
+      hash.each do |key, value|
+        key = key.to_s.downcase
+        if key == 'type'
+          new_type_hash = {}
+          raise ArgumentError unless value.is_a?(Hash)
+          value.each{ |subkey, subvalue|
+            subkey = subkey.to_s.downcase
+            if ValidTypeKeys.include?(subkey)
+              new_type_hash[subkey] = subvalue
+            else
+              raise ArgumentError, "Invalid type key '#{subkey}'"
+            end
+          }
+          new_hash[key] = new_type_hash
+        else
+          if ValidKeys.include?(key)
+            new_hash[key] = value
+          else
+            raise ArgumentError, "Invalid key '#{key}'"
+          end
+        end
+      end
+
+      new_hash
+    end
+
     # iTrigger is a COM ITrigger instance
     def self.from_iTrigger(iTrigger)
       require 'puppet/util/windows/taskscheduler' # Needed for the WIN32::ScheduledTask flag constants

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -214,7 +214,7 @@ module Trigger
       V1_TYPE_MAP[v1type]
     end
 
-    def self.append_trigger(definition, v1trigger)
+    def self.append_v1trigger(definition, v1trigger)
       v1trigger = Trigger::V1.canonicalize_and_validate(v1trigger)
 
       trigger_type = type_from_v1type(v1trigger['trigger_type'])

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -198,6 +198,22 @@ module Trigger
     end
 
   end
+
+  class V2
+    V1_TYPE_MAP =
+    {
+      :TASK_TIME_TRIGGER_DAILY => TaskScheduler2::TASK_TRIGGER_DAILY,
+      :TASK_TIME_TRIGGER_WEEKLY => TaskScheduler2::TASK_TRIGGER_WEEKLY,
+      :TASK_TIME_TRIGGER_MONTHLYDATE => TaskScheduler2::TASK_TRIGGER_MONTHLY,
+      :TASK_TIME_TRIGGER_MONTHLYDOW => TaskScheduler2::TASK_TRIGGER_MONTHLYDOW,
+      :TASK_TIME_TRIGGER_ONCE => TaskScheduler2::TASK_TRIGGER_TIME,
+    }.freeze
+
+    def self.type_from_v1type(v1type)
+      raise ArgumentError.new(_("Unknown V1 trigger Type %{type}") % { type: v1type }) unless V1_TYPE_MAP.keys.include?(v1type)
+      V1_TYPE_MAP[v1type]
+    end
+  end
 end
 end
 end

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -62,6 +62,15 @@ module Trigger
   end
   module_function :string_to_int
 
+  def date_part_to_int(value, datepart)
+    return 0 if value.nil?
+    return 0 unless value.is_a?(String)
+    return 0 if value.empty?
+
+    DateTime.parse(value).strftime(datepart).to_i
+  end
+  module_function :date_part_to_int
+
 end
 end
 end

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -32,14 +32,14 @@ module Trigger
     return 0 if value.nil?
     time = 0
     # Note - the Year and Month calculations are approximate
-    time = time + value[:year].to_i   * (365.2422 * 24 * 60**2).to_i unless value[:year].nil?
-    time = time + value[:month].to_i  * (365.2422 * 2 * 60**2).to_i  unless value[:month].nil?
+    time = time + value[:year].to_i   * (365.2422 * 24 * 60**2)      unless value[:year].nil?
+    time = time + value[:month].to_i  * (365.2422 * 2 * 60**2)       unless value[:month].nil?
     time = time + value[:day].to_i    * 24 * 60**2                   unless value[:day].nil?
     time = time + value[:hour].to_i   * 60**2                        unless value[:hour].nil?
     time = time + value[:minute].to_i * 60                           unless value[:minute].nil?
     time = time + value[:second].to_i                                unless value[:second].nil?
 
-    time
+    time.to_i
   end
   module_function :duration_hash_to_seconds
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -1,0 +1,34 @@
+# @api private
+module PuppetX
+module PuppetLabs
+module ScheduledTask
+
+module Trigger
+  # From https://msdn.microsoft.com/en-us/library/windows/desktop/aa381850(v=vs.85).aspx
+  # https://en.wikipedia.org/wiki/ISO_8601#Durations
+  #
+  # The format for this string is PnYnMnDTnHnMnS, where nY is the number of years, nM is the number of months,
+  # nD is the number of days, 'T' is the date/time separator, nH is the number of hours, nM is the number of minutes,
+  # and nS is the number of seconds (for example, PT5M specifies 5 minutes and P1M4DT2H5M specifies one month,
+  # four days, two hours, and five minutes)
+  def duration_to_hash(duration)
+    regex = /^P((?'year'\d+)Y)?((?'month'\d+)M)?((?'day'\d+)D)?(T((?'hour'\d+)H)?((?'minute'\d+)M)?((?'second'\d+)S)?)?$/
+
+    matches = regex.match(duration)
+    return nil if matches.nil?
+
+    {
+      :year => matches['year'],
+      :month => matches['month'],
+      :day => matches['day'],
+      :minute => matches['minute'],
+      :hour => matches['hour'],
+      :second => matches['second'],
+    }
+  end
+  module_function :duration_to_hash
+
+end
+end
+end
+end

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -71,6 +71,11 @@ module Trigger
   end
   module_function :string_to_date
 
+  def normalize_datetime(year, month, day, hour, minute)
+    DateTime.new(year, month, day, hour, minute, 0).strftime('%FT%T')
+  end
+  module_function :normalize_datetime
+
 end
 end
 end

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -55,9 +55,8 @@ module Trigger
 
   def string_to_int(value)
     return 0 if value.nil?
-    return value if value.is_a?(Integer)
-    return 0 unless value.is_a?(String)
-    return 0 if value.empty?
+    return value if value.is_a?(Numeric)
+    raise ArgumentError.new('value must be a String') unless value.is_a?(String)
 
     value.to_i
   end

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -63,9 +63,8 @@ module Trigger
   module_function :string_to_int
 
   def date_part_to_int(value, datepart)
-    return 0 if value.nil?
-    return 0 unless value.is_a?(String)
-    return 0 if value.empty?
+    return 0 if value.nil? || value.empty?
+    raise ArgumentError.new('value must be a String') unless value.is_a?(String)
 
     DateTime.parse(value).strftime(datepart).to_i
   end

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -109,9 +109,9 @@ module Trigger
     # canonicalize given trigger hash
     # throws errors if hash structure is invalid
     # @returns original object with downcased keys
-    def self.transform_and_validate(hash)
+    def self.canonicalize_and_validate(hash)
       raise TypeError unless hash.is_a?(Hash)
-      new_hash = {}
+      hash = downcase_keys(hash)
 
       invalid_keys = hash.keys - ValidKeys
       raise ArgumentError.new("Invalid trigger keys #{invalid_keys}") unless invalid_keys.empty?

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
@@ -32,7 +32,7 @@ def create_test_task(task_name = nil, task_compatiblity = PuppetX::PuppetLabs::S
   tasksched.set_principal(definition, '')
   definition.Settings.Enabled = false
   # Create a trigger
-  trigger = tasksched.append_new_trigger(definition, tasksched::TASK_TRIGGER_TIME)
+  trigger = definition.Triggers.Create(tasksched::TASK_TRIGGER_TIME)
   trigger.StartBoundary = '2017-09-11T14:02:00'
   # Create an action
   new_action = tasksched.create_action(definition, tasksched::TASK_ACTION_EXEC)

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require 'spec_helper'
 require 'puppet_x/puppetlabs/scheduled_task/taskscheduler2'
+require 'puppet_x/puppetlabs/scheduled_task/trigger'
 
 RSpec::Matchers.define :be_same_as_powershell_command do |ps_cmd|
   define_method :run_ps do |cmd|
@@ -23,8 +24,10 @@ RSpec::Matchers.define :be_same_as_powershell_command do |ps_cmd|
   end
 end
 
-def create_test_task(task_name = nil, task_compatiblity = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_V2)
-  tasksched = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2
+ST = PuppetX::PuppetLabs::ScheduledTask
+
+def create_test_task(task_name = nil, task_compatiblity = ST::TaskScheduler2::TASK_COMPATIBILITY_V2)
+  tasksched = ST::TaskScheduler2
   task_name = tasksched::ROOT_FOLDER + 'puppet_task_' + SecureRandom.uuid.to_s if task_name.nil?
   definition = tasksched.new_task_definition
   # Set task settings
@@ -32,7 +35,7 @@ def create_test_task(task_name = nil, task_compatiblity = PuppetX::PuppetLabs::S
   tasksched.set_principal(definition, '')
   definition.Settings.Enabled = false
   # Create a trigger
-  trigger = definition.Triggers.Create(tasksched::TASK_TRIGGER_TIME)
+  trigger = definition.Triggers.Create(ST::Trigger::V2::Type::TASK_TRIGGER_TIME)
   trigger.StartBoundary = '2017-09-11T14:02:00'
   # Create an action
   new_action = tasksched.create_action(definition, tasksched::TASK_ACTION_EXEC)
@@ -133,7 +136,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2", :if => Puppet.fea
       end
 
       it 'should have a trigger of type TimeTrigger' do
-        expect(subject.trigger(task_definition, 1).Type).to eq(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_TRIGGER_TIME)
+        expect(subject.trigger(task_definition, 1).Type).to eq(ST::Trigger::V2::Type::TASK_TRIGGER_TIME)
       end
 
       it 'should have a single action' do

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -64,7 +64,7 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger do
 end
 
 describe PuppetX::PuppetLabs::ScheduledTask::Trigger::V1 do
-  describe "#transform_and_validate" do
+  describe "#canonicalize_and_validate" do
     [
       {
         :input =>
@@ -123,7 +123,7 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger::V1 do
       },
     ].each do |value|
       it "should return downcased keys #{value[:expected]} given a hash with valid case-insensitive keys #{value[:input]}" do
-        expect(subject.class.transform_and_validate(value[:input])).to eq(value[:expected])
+        expect(subject.class.canonicalize_and_validate(value[:input])).to eq(value[:expected])
       end
     end
 
@@ -135,7 +135,7 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger::V1 do
       { 'type' => 1 },
     ].each do |value|
       it "should fail with ArgumentError given a hash with invalid keys #{value}" do
-        expect { subject.class.transform_and_validate(value) }.to raise_error(ArgumentError)
+        expect { subject.class.canonicalize_and_validate(value) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -26,6 +26,27 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger do
       end
     end
   end
+
+  describe "#date_part_to_int" do
+    [nil, '', :foo, [], {}].each do |value|
+      it "should return 0 given value '#{value}' (#{value.class})" do
+        expect(subject.date_part_to_int(value, '')).to be_zero
+      end
+    end
+
+    [
+      { :input => ['2018-01-02T03:04:05', '%Y'], :expected => 2018 },
+      { :input => ['2018-01-02T03:04:05', '%m'], :expected => 1 },
+      { :input => ['2018-01-02T03:04:05', '%d'], :expected => 2 },
+      { :input => ['2018-01-02T03:04:05', '%H'], :expected => 3 },
+      { :input => ['2018-01-02T03:04:05', '%M'], :expected => 4 },
+      { :input => ['2018-01-02T03:04:05', '%S'], :expected => 5 },
+    ].each do |value|
+      it "should return numeric input #{value[:expected]} for date string #{value[:input]}" do
+        expect(subject.date_part_to_int(*value[:input])).to eq(value[:expected])
+      end
+    end
+  end
 end
 
 describe PuppetX::PuppetLabs::ScheduledTask::Trigger::Duration do

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -1,0 +1,62 @@
+#!/usr/bin/env ruby
+require 'spec_helper'
+require 'puppet_x/puppetlabs/scheduled_task/trigger'
+
+describe "PuppetX::PuppetLabs::ScheduledTask::Trigger", :if => Puppet.features.microsoft_windows? do
+  let(:subject) { PuppetX::PuppetLabs::ScheduledTask::Trigger }
+
+  EXPECTED_CONVERSIONS =
+  [
+    {
+      :duration => 'P1M4DT2H5M',
+      :duration_hash => {
+        :year => nil,
+        :month => "1",
+        :day => "4",
+        :minute => "5",
+        :hour => "2",
+        :second => nil,
+      },
+    },
+    {
+      :duration => 'PT20M',
+      :duration_hash => {
+        :year => nil,
+        :month => nil,
+        :day => nil,
+        :minute => "20",
+        :hour => nil,
+        :second => nil,
+      },
+    },
+    {
+      :duration => 'P1Y2M30DT12H60M60S',
+      :duration_hash => {
+        :year => "1",
+        :month => "2",
+        :day => "30",
+        :minute => "60",
+        :hour => "12",
+        :second => "60",
+      },
+    },
+  ].freeze
+
+  describe '#duration_to_hash' do
+    EXPECTED_CONVERSIONS.each do |conversion|
+      it "should create expected hashes from duration string #{conversion[:duration]}" do
+        expect(subject.duration_to_hash(conversion[:duration])).to eq(conversion[:duration_hash])
+      end
+    end
+
+    [
+      'ABC',
+      '123'
+    ]
+    .each do |duration|
+      it "should return nil when failing to parse duration string #{duration}" do
+        expect(subject.duration_to_hash(duration)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -2,6 +2,25 @@
 require 'spec_helper'
 require 'puppet_x/puppetlabs/scheduled_task/trigger'
 
+describe PuppetX::PuppetLabs::ScheduledTask::Trigger do
+  describe "#string_to_int" do
+    [nil, '', :foo, 1.2, [], {}].each do |value|
+      it "should return 0 given value '#{value}' (#{value.class})" do
+        expect(subject.string_to_int(value)).to be_zero
+      end
+    end
+
+    [
+      { :input => 0, :expected => 0 },
+      { :input => 100, :expected => 100 }
+    ].each do |value|
+      it "should coerce numeric input #{value[:input]} to #{value[:expected]}" do
+        expect(subject.string_to_int(value[:input])).to eq(value[:expected])
+      end
+    end
+  end
+end
+
 describe PuppetX::PuppetLabs::ScheduledTask::Trigger::Duration do
   DAYS_IN_YEAR = 365.2422
   SECONDS_IN_HOUR = 60 * 60

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -4,7 +4,7 @@ require 'puppet_x/puppetlabs/scheduled_task/trigger'
 
 describe PuppetX::PuppetLabs::ScheduledTask::Trigger do
   describe "#string_to_int" do
-    [nil, '', :foo, 1.2, [], {}].each do |value|
+    [nil, ''].each do |value|
       it "should return 0 given value '#{value}' (#{value.class})" do
         expect(subject.string_to_int(value)).to be_zero
       end
@@ -12,10 +12,17 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger do
 
     [
       { :input => 0, :expected => 0 },
+      { :input => 1.2, :expected => 1.2} ,
       { :input => 100, :expected => 100 }
     ].each do |value|
       it "should coerce numeric input #{value[:input]} to #{value[:expected]}" do
         expect(subject.string_to_int(value[:input])).to eq(value[:expected])
+      end
+    end
+
+    [:foo, [], {}].each do |value|
+      it "should raise ArgumentError given value '#{value}' (#{value.class})" do
+        expect { subject.string_to_int(value) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -45,8 +45,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::Trigger", :if => Puppet.features.m
         :hour => "12",
         :second => "60",
       },
-      # NOTE: -1 for rounding bug
-      :expected_seconds => (DAYS_IN_YEAR * SECONDS_IN_DAY) + ((DAYS_IN_YEAR / 12 * 2) * SECONDS_IN_DAY) + (30 * SECONDS_IN_DAY) + (60 * 60) + (SECONDS_IN_HOUR * 12) + 60 - 1
+      :expected_seconds => (DAYS_IN_YEAR * SECONDS_IN_DAY) + ((DAYS_IN_YEAR / 12 * 2) * SECONDS_IN_DAY) + (30 * SECONDS_IN_DAY) + (60 * 60) + (SECONDS_IN_HOUR * 12) + 60
     },
   ].freeze
 

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -63,6 +63,84 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger do
   end
 end
 
+describe PuppetX::PuppetLabs::ScheduledTask::Trigger::V1 do
+  describe "#transform_and_validate" do
+    [
+      {
+        :input =>
+        {
+          'END_day' => nil,
+          'end_Month' => nil,
+          'End_year' => nil,
+          'FLAGS' => nil,
+          'minutes_duration' => nil,
+          'MINutes_intERVAL' => nil,
+          'Random_Minutes_Interval' => nil,
+          'Start_day' => nil,
+          'START_hour' => nil,
+          'start_Minute' => nil,
+          'start_YEAR' => nil,
+          'Trigger_Type' => nil,
+          'TyPe' =>
+          {
+            'days_Interval' => nil,
+            'Weeks_interval' => nil,
+            'DAYS_of_Week' => nil,
+            'MONTHS' => nil,
+            'daYS' => nil,
+            'weeks' => nil
+          }
+        },
+        # all keys are lower
+        :expected =>
+        {
+          'end_day' => nil,
+          'end_month' => nil,
+          'end_year' => nil,
+          'flags' => nil,
+          'minutes_duration' => nil,
+          'minutes_interval' => nil,
+          'random_minutes_interval' => nil,
+          'start_day' => nil,
+          'start_hour' => nil,
+          'start_minute' => nil,
+          'start_year' => nil,
+          'trigger_type' => nil,
+          'type' =>
+          {
+            'days_interval' => nil,
+            'weeks_interval' => nil,
+            'days_of_week' => nil,
+            'months' => nil,
+            'days' => nil,
+            'weeks' => nil
+          }
+        }
+      },
+      {
+        :input => { 'type' => { 'DAYS_Interval' => nil, } },
+        :expected => { 'type' => { 'days_interval' => nil, } },
+      },
+    ].each do |value|
+      it "should return downcased keys #{value[:expected]} given a hash with valid case-insensitive keys #{value[:input]}" do
+        expect(subject.class.transform_and_validate(value[:input])).to eq(value[:expected])
+      end
+    end
+
+    [
+      { :foo => nil, 'type' => {} },
+      { [] => nil },
+      { 'type' => [] },
+      { 'type' => 1 },
+    ].each do |value|
+      it "should fail with ArgumentError given a hash with invalid keys #{value}" do
+        expect { subject.class.transform_and_validate(value) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+end
+
 describe PuppetX::PuppetLabs::ScheduledTask::Trigger::Duration do
   DAYS_IN_YEAR = 365.2422
   SECONDS_IN_HOUR = 60 * 60

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -50,14 +50,14 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger do
     end
   end
 
-  describe "#normalize_datetime" do
+  describe "#iso8601_datetime" do
     [
       # year, month, day, hour, minute
-      { :input => [2018, 3, 20, 8, 57], :expected => '2018-03-20T08:57:00' },
-      { :input => [1899, 12, 30, 0, 0], :expected => '1899-12-30T00:00:00' },
+      { :input => [2018, 3, 20, 8, 57], :expected => '2018-03-20T08:57:00+00:00' },
+      { :input => [1899, 12, 30, 0, 0], :expected => '1899-12-30T00:00:00+00:00' },
     ].each do |value|
       it "should return formatted date string #{value[:expected]} for date components #{value[:input]}" do
-        expect(subject.normalize_datetime(*value[:input])).to eq(value[:expected])
+        expect(subject.iso8601_datetime(*value[:input])).to eq(value[:expected])
       end
     end
   end

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -27,29 +27,25 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger do
     end
   end
 
-  describe "#date_part_to_int" do
+  describe "#string_to_date" do
     [nil, ''].each do |value|
-      it "should return 0 given value '#{value}' (#{value.class})" do
-        expect(subject.date_part_to_int(value, '')).to be_zero
+      it "should return nil given value '#{value}' (#{value.class})" do
+        expect(subject.string_to_date(value)).to eq(nil)
       end
     end
 
     [
-      { :input => ['2018-01-02T03:04:05', '%Y'], :expected => 2018 },
-      { :input => ['2018-01-02T03:04:05', '%m'], :expected => 1 },
-      { :input => ['2018-01-02T03:04:05', '%d'], :expected => 2 },
-      { :input => ['2018-01-02T03:04:05', '%H'], :expected => 3 },
-      { :input => ['2018-01-02T03:04:05', '%M'], :expected => 4 },
-      { :input => ['2018-01-02T03:04:05', '%S'], :expected => 5 },
+      { :input => '2018-01-02T03:04:05', :expected => DateTime.new(2018, 1, 2, 3, 4, 5) },
+      { :input => '1899-12-30T00:00:00', :expected => DateTime.new(1899, 12, 30, 0, 0, 0) },
     ].each do |value|
-      it "should return numeric input #{value[:expected]} for date string #{value[:input]}" do
-        expect(subject.date_part_to_int(*value[:input])).to eq(value[:expected])
+      it "should return a valid DateTime object for date string #{value[:input]}" do
+        expect(subject.string_to_date(value[:input])).to eq(value[:expected])
       end
     end
 
     [:foo, [], {}].each do |value|
       it "should raise ArgumentError given value '#{value}' (#{value.class})" do
-        expect { subject.date_part_to_int(value) }.to raise_error(ArgumentError)
+        expect { subject.string_to_date(value) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -28,7 +28,7 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger do
   end
 
   describe "#date_part_to_int" do
-    [nil, '', :foo, [], {}].each do |value|
+    [nil, ''].each do |value|
       it "should return 0 given value '#{value}' (#{value.class})" do
         expect(subject.date_part_to_int(value, '')).to be_zero
       end
@@ -44,6 +44,12 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger do
     ].each do |value|
       it "should return numeric input #{value[:expected]} for date string #{value[:input]}" do
         expect(subject.date_part_to_int(*value[:input])).to eq(value[:expected])
+      end
+    end
+
+    [:foo, [], {}].each do |value|
+      it "should raise ArgumentError given value '#{value}' (#{value.class})" do
+        expect { subject.date_part_to_int(value) }.to raise_error(ArgumentError)
       end
     end
   end

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -129,6 +129,7 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger::V1 do
 
     [
       { :foo => nil, 'type' => {} },
+      { :type => nil },
       { [] => nil },
       { 'type' => [] },
       { 'type' => 1 },

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -2,9 +2,7 @@
 require 'spec_helper'
 require 'puppet_x/puppetlabs/scheduled_task/trigger'
 
-describe "PuppetX::PuppetLabs::ScheduledTask::Trigger", :if => Puppet.features.microsoft_windows? do
-  let(:subject) { PuppetX::PuppetLabs::ScheduledTask::Trigger }
-
+describe PuppetX::PuppetLabs::ScheduledTask::Trigger::Duration do
   DAYS_IN_YEAR = 365.2422
   SECONDS_IN_HOUR = 60 * 60
   SECONDS_IN_DAY = 24 * SECONDS_IN_HOUR
@@ -49,10 +47,10 @@ describe "PuppetX::PuppetLabs::ScheduledTask::Trigger", :if => Puppet.features.m
     },
   ].freeze
 
-  describe '#duration_to_hash' do
+  describe '#to_hash' do
     EXPECTED_CONVERSIONS.each do |conversion|
       it "should create expected hashes from duration string #{conversion[:duration]}" do
-        expect(subject.duration_to_hash(conversion[:duration])).to eq(conversion[:duration_hash])
+        expect(subject.class.to_hash(conversion[:duration])).to eq(conversion[:duration_hash])
       end
     end
 
@@ -62,44 +60,44 @@ describe "PuppetX::PuppetLabs::ScheduledTask::Trigger", :if => Puppet.features.m
     ]
     .each do |duration|
       it "should return nil when failing to parse duration string #{duration}" do
-        expect(subject.duration_to_hash(duration)).to be_nil
+        expect(subject.class.to_hash(duration)).to be_nil
       end
     end
   end
 
-  describe '#duration_hash_to_seconds' do
+  describe '#hash_to_seconds' do
     it "should return 0 for a nil value" do
-      expect(subject.duration_hash_to_seconds(nil)).to be_zero
+      expect(subject.class.hash_to_seconds(nil)).to be_zero
     end
 
     EXPECTED_CONVERSIONS.each do |conversion|
       rounded_seconds = conversion[:expected_seconds].to_i
       it "should return #{rounded_seconds} seconds given a duration hash" do
-        converted = subject.duration_hash_to_seconds(conversion[:duration_hash])
+        converted = subject.class.hash_to_seconds(conversion[:duration_hash])
         expect(converted).to eq(rounded_seconds)
       end
     end
   end
 
-  describe '#duration_to_minutes' do
+  describe '#to_minutes' do
     it "should return 0 for a nil value" do
-      expect(subject.duration_to_minutes(nil)).to be_zero
+      expect(subject.class.to_minutes(nil)).to be_zero
     end
 
     it "should return 0 for an empty string value" do
-      expect(subject.duration_to_minutes('')).to be_zero
+      expect(subject.class.to_minutes('')).to be_zero
     end
 
     [1234, '0', 999.999].each do |value|
       it "should return 0 for the #{value.class} value: #{value}" do
-        expect(subject.duration_to_minutes(value)).to be_zero
+        expect(subject.class.to_minutes(value)).to be_zero
       end
     end
 
     EXPECTED_CONVERSIONS.each do |conversion|
       expected_minutes = conversion[:expected_seconds].to_i / 60
       it "should return #{expected_minutes} minutes given a duration #{conversion[:duration]}" do
-        converted = subject.duration_to_minutes(conversion[:duration])
+        converted = subject.class.to_minutes(conversion[:duration])
         expect(converted).to eq(expected_minutes)
       end
     end

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -49,6 +49,18 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger do
       end
     end
   end
+
+  describe "#normalize_datetime" do
+    [
+      # year, month, day, hour, minute
+      { :input => [2018, 3, 20, 8, 57], :expected => '2018-03-20T08:57:00' },
+      { :input => [1899, 12, 30, 0, 0], :expected => '1899-12-30T00:00:00' },
+    ].each do |value|
+      it "should return formatted date string #{value[:expected]} for date components #{value[:input]}" do
+        expect(subject.normalize_datetime(*value[:input])).to eq(value[:expected])
+      end
+    end
+  end
 end
 
 describe PuppetX::PuppetLabs::ScheduledTask::Trigger::Duration do


### PR DESCRIPTION
#14 should be merged first which restores existing type / provider to this module

- Report on the compatibility level of tasks enumerated from the
   system.

   This requires adding a value to the scheduled_task type named
   compatibility. Based on how the provider works, it currently only
   enumerates v1 tasks, and therefore only returns 1.

   Since the property may now also be set in a manifest, limit the
   value to 1 so that it cannot be set improperly. Default the value
   to 1 to preserve backward compatibility.

   `puppet resource` will now emit the value as well