### PR TITLE
(MODULES-6398) Fix error message on invalid day_of_week trigger

### DIFF
--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -440,7 +440,9 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
 
     days_of_week = [days_of_week] unless days_of_week.is_a?(Array)
     days_of_week.each do |day_of_week|
-      bitfield |= day_of_week_name_to_constant(day_of_week)
+      bitmask = day_of_week_name_to_constant(day_of_week)
+      self.fail "Days_of_week value #{day_of_week} is invalid. Expected sun, mon, tue, wed, thu, fri or sat." if bitmask.nil?
+      bitfield |= bitmask
     end
 
     bitfield

--- a/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
+++ b/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
@@ -438,7 +438,9 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
 
     days_of_week = [days_of_week] unless days_of_week.is_a?(Array)
     days_of_week.each do |day_of_week|
-      bitfield |= day_of_week_name_to_constant(day_of_week)
+      bitmask = day_of_week_name_to_constant(day_of_week)
+      self.fail "Days_of_week value #{day_of_week} is invalid. Expected sun, mon, tue, wed, thu, fri or sat." if bitmask.nil?
+      bitfield |= bitmask
     end
 
     bitfield

--- a/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -1567,6 +1567,17 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
         /#{Regexp.escape("Unknown trigger option(s): ['this is invalid']")}/
       )
     end
+
+    it 'should raise when an invalid day_of_week is passed' do
+      triggers_to_validate = [
+        {'schedule' => 'weekly', 'start_date' => '2011-09-13', 'start_time' => '13:50', 'day_of_week' => 'BadDay'}
+      ]
+
+      expect {provider.validate_trigger(triggers_to_validate)}.to raise_error(
+        Puppet::Error,
+        /#{Regexp.escape("Days_of_week value BadDay is invalid")}/
+      )
+    end
   end
 
   describe '#flush' do


### PR DESCRIPTION
Previously if an invalid value for the day_of_week property was passed (e.g.
MON) it would fail with `Cannot convert "nil" to Fixnum`.  This commit adds
invalid value detection when building the bitmasked value and raises an error
which includes the bad value.  This commit also adds a test for this scenario.