### PR TITLE
(MODULES-6268) Fix error when switching monthly trigger types

### DIFF
--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -241,6 +241,7 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
   def triggers_same?(current_trigger, desired_trigger)
     return false unless current_trigger['schedule'] == desired_trigger['schedule']
     return false if current_trigger.has_key?('enabled') && !current_trigger['enabled']
+    return false if translate_hash_to_trigger(desired_trigger)['trigger_type'] != translate_hash_to_trigger(current_trigger)['trigger_type']
 
     desired = desired_trigger.dup
     desired['start_date']  ||= current_trigger['start_date']  if current_trigger.has_key?('start_date')

--- a/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
+++ b/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
@@ -240,6 +240,7 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
   def triggers_same?(current_trigger, desired_trigger)
     return false unless current_trigger['schedule'] == desired_trigger['schedule']
     return false if current_trigger.has_key?('enabled') && !current_trigger['enabled']
+    return false if translate_hash_to_trigger(desired_trigger)['trigger_type'] != translate_hash_to_trigger(current_trigger)['trigger_type']
 
     desired = desired_trigger.dup
     desired['start_date']  ||= current_trigger['start_date']  if current_trigger.has_key?('start_date')

--- a/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -815,6 +815,15 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
       expect(provider).not_to be_triggers_same(current, desired)
     end
 
+    it 'should not consider triggers with different monthly types to be the same' do
+      # A trigger of type Win32::TaskScheduler::MONTHLYDATE
+      current = {'schedule' => 'monthly', 'start_time' => '14:00', 'months' => [1,2,3,4,5,6,7,8,9,10,11,12], 'on' => [9]}
+      # A trigger of type Win32::TaskScheduler::MONTHLYDOW
+      desired = {'schedule' => 'monthly', 'start_time' => '14:00', 'which_occurrence' => 'second', 'day_of_week' => ['sat']}
+
+      expect(provider).not_to be_triggers_same(current, desired)
+    end
+
     describe 'start_date' do
       it "considers triggers to be equal when start_date is not specified in the 'desired' trigger" do
         current = {'schedule' => 'daily', 'start_date' => '2011-09-12', 'start_time' => '15:30', 'every' => 3}


### PR DESCRIPTION
Previously when changing from a monthly day of week to a monthly date trigger
type (and vice versa) Puppet would raise an error.  This was due to Puppet using
the same schedule name (monthly) for two distinct trigger types in windows API.
This commit adds an additional check to the tiggers_same? method which also
evaluates the underlying trigger type, not just the Puppet representation to
determine if two triggers are indeed the same.  This commit also adds tests for
this scenario.