### PR TITLE
(MODULES-6844) Add v2-only helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ For all triggers:
   You should format dates as YYYY-MM-DD, although other date formats may work (under the hood, this uses Date.parse).
 * `minutes_interval` — The repeat interval in minutes.
 * `minutes_duration` — The duration in minutes, needs to be greater than the minutes_interval.
+* `random_minutes_interval` — The delay time that is randomly added to the start time of the trigger.
 * For daily triggers:
   * `every` — How often the task should run, as a number of days.
     Defaults to 1.

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
@@ -1,0 +1,260 @@
+# This class is used to manage V1 compatible tasks using the Task Scheduler V2 API
+# It is designed to be a binary compatible API to puppet/util/windows/taskscheduler.rb but
+# will only surface the features used by the Puppet scheduledtask provider
+#
+require_relative './taskscheduler2'
+require_relative './trigger'
+
+module PuppetX
+module PuppetLabs
+module ScheduledTask
+
+class TaskScheduler2Task
+  # The error class raised if any task scheduler specific calls fail.
+  class Error < Puppet::Util::Windows::Error; end
+
+  public
+  # Returns a new TaskScheduler object. If a work_item (and possibly the
+  # the trigger) are passed as arguments then a new work item is created and
+  # associated with that trigger, although you can still activate other tasks
+  # with the same handle.
+  #
+  # This is really just a bit of convenience. Passing arguments to the
+  # constructor is the same as calling TaskScheduler.new plus
+  # TaskScheduler#new_work_item.
+  #
+  def initialize(work_item = nil, trigger = nil)
+    @tasksched = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2
+
+    new_work_item(work_item, trigger) if work_item && trigger
+  end
+
+  # Returns an array of scheduled task names.
+  #
+  # Emulates V1 tasks by appending the '.job' suffix
+  #
+  def enum
+    @tasksched.enum_task_names(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::ROOT_FOLDER,
+      include_child_folders: false,
+      include_compatibility: [PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_AT, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_V1]).map do |item|
+        @tasksched.task_name_from_task_path(item) + '.job'
+    end
+  end
+  alias :tasks :enum
+
+  # Activate the specified task.
+  #
+  def activate(task_name)
+    raise TypeError unless task_name.is_a?(String)
+    normal_task_name = normalize_task_name(task_name)
+    raise Error.new(_("Scheduled Task %{task_name} does not exist") % { task_name: normal_task_name }) unless exists?(normal_task_name)
+
+    full_taskname = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::ROOT_FOLDER + normal_task_name
+
+    @task = @tasksched.task(full_taskname)
+    @full_task_path = full_taskname
+    @definition = @tasksched.task_definition(@task)
+    @task_password = nil
+
+    @task
+  end
+
+  # Delete the specified task name.
+  #
+  def delete(task_name)
+    full_taskname = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::ROOT_FOLDER + normalize_task_name(task_name)
+    @tasksched.delete(full_taskname)
+  end
+
+  # Saves the current task. Tasks must be saved before they can be activated.
+  # The .job file itself is typically stored in the C:\WINDOWS\Tasks folder.
+  #
+  # If +file+ (an absolute path) is specified then the job is saved to that
+  # file instead. A '.job' extension is recommended but not enforced.
+  #
+  def save(file = nil)
+    task_object = @task.nil? ? @full_task_path : @task
+    @tasksched.save(task_object, @definition, @task_password)
+  end
+
+  # Sets the +user+ and +password+ for the given task. If the user and
+  # password are set properly then true is returned.
+  #
+  # In some cases the job may be created, but the account information was
+  # bad. In this case the task is created but a warning is generated and
+  # false is returned.
+  #
+  # Note that if intending to use SYSTEM, specify an empty user and nil password
+  #
+  # Calling task.set_account_information('SYSTEM', nil) will generally not
+  # work, except for one special case where flags are also set like:
+  # task.flags = Win32::TaskScheduler::TASK_FLAG_RUN_ONLY_IF_LOGGED_ON
+  #
+  # This must be done prior to the 1st save() call for the task to be
+  # properly registered and visible through the MMC snap-in / schtasks.exe
+  #
+  def set_account_information(user, password)
+    @task_password = password
+    @tasksched.set_principal(@definition, user)
+  end
+
+  # Returns the user associated with the task or nil if no user has yet
+  # been associated with the task.
+  #
+  def account_information
+    principal = @tasksched.principal(@definition)
+    principal.nil? ? nil : principal.UserId
+  end
+
+  # Returns the name of the application associated with the task.
+  #
+  def application_name
+    action = default_action(create_if_missing: false)
+    action.nil? ? nil : action.Path
+  end
+
+  # Sets the application name associated with the task.
+  #
+  def application_name=(app)
+    action = default_action(create_if_missing: true)
+    action.Path = app
+    app
+  end
+
+  # Returns the command line parameters for the task.
+  #
+  def parameters
+    action = default_action(create_if_missing: false)
+    action.nil? ? nil : action.Arguments
+  end
+
+  # Sets the parameters for the task. These parameters are passed as command
+  # line arguments to the application the task will run. To clear the command
+  # line parameters set it to an empty string.
+  #
+  def parameters=(param)
+    action = default_action(create_if_missing: true)
+    action.Arguments = param
+    param
+  end
+
+  # Returns the working directory for the task.
+  #
+  def working_directory
+    action = default_action(create_if_missing: false)
+    action.nil? ? nil : action.WorkingDirectory
+  end
+
+  # Sets the working directory for the task.
+  #
+  def working_directory=(dir)
+    action = default_action(create_if_missing: false)
+    action.WorkingDirectory = dir
+    dir
+  end
+
+  # Creates a new work item (scheduled job) with the given +trigger+. The
+  # trigger variable is a hash of options that define when the scheduled
+  # job should run.
+  #
+  def new_work_item(task_name, task_trigger)
+    raise TypeError unless task_trigger.is_a?(Hash)
+
+    @full_task_path = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::ROOT_FOLDER + normalize_task_name(task_name)
+    @definition = @tasksched.new_task_definition
+    @task = nil
+    @task_password = nil
+
+    @tasksched.set_compatibility(@definition, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_V1)
+
+    Trigger::V2.append_v1trigger(@definition, task_trigger)
+
+    set_account_information('',nil)
+
+    @definition
+  end
+  alias :new_task :new_work_item
+
+  # Returns the number of triggers associated with the active task.
+  #
+  def trigger_count
+    @tasksched.trigger_count(@definition)
+  end
+
+  # Deletes the trigger at the specified index.
+  #
+  def delete_trigger(index)
+    # The older V1 API uses a starting index of zero, wherease the V2 API uses one.
+    # Need to increment by one to maintain the same behavior
+    @tasksched.delete_trigger(@definition, index + 1)
+  end
+
+  # Returns a hash that describes the trigger at the given index for the
+  # current task.
+  #
+  def trigger(index)
+    # The older V1 API uses a starting index of zero, wherease the V2 API uses one.
+    # Need to increment by one to maintain the same behavior
+    trigger_object = @tasksched.trigger(@definition, index + 1)
+    trigger_object.nil? ? nil : Trigger::V1.from_iTrigger(trigger_object)
+  end
+
+  # Sets the trigger for the currently active task.
+  #
+  # Note - This method name is a mis-nomer. It's actually appending a newly created trigger to the trigger collection.
+  def trigger=(v1trigger)
+    Trigger::V2.append_v1trigger(@definition, v1trigger)
+  end
+
+  # Returns the flags (integer) that modify the behavior of the work item. You
+  # must OR the return value to determine the flags yourself.
+  #
+  def flags
+    flags = 0
+    flags = flags | Win32::TaskScheduler::DISABLED if !@definition.Settings.Enabled
+    flags
+  end
+
+  # Sets an OR'd value of flags that modify the behavior of the work item.
+  #
+  def flags=(flags)
+    @definition.Settings.Enabled = (flags & Win32::TaskScheduler::DISABLED == 0)
+  end
+
+  # Returns whether or not the scheduled task exists.
+  def exists?(job_name)
+    # task name comparison is case insensitive
+    enum.any? { |name| name.casecmp(job_name + '.job') == 0 }
+  end
+
+  private
+  # :stopdoc:
+
+  def normalize_task_name(task_name)
+    # The Puppet provider and some other instances may pass a '.job' suffix as per the V1 API
+    # This is not needed for the V2 API so we just remove it
+    task_name = task_name.slice(0,task_name.length - 4) if task_name.end_with?('.job')
+
+    task_name
+  end
+
+  # Find the first TASK_ACTION_EXEC action
+  def default_action(create_if_missing: false)
+    action = nil
+    (1..@tasksched.action_count(@definition)).each do |i|
+      index_action = @tasksched.action(@definition, i)
+      action = index_action if index_action.Type == PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_ACTION_EXEC
+      break if action
+    end
+
+    if action.nil? && create_if_missing
+      action = @tasksched.create_action(@definition, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_ACTION_EXEC)
+    end
+
+    action
+  end
+end
+
+end
+end
+end

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
@@ -1,7 +1,4 @@
 # This class is used to manage V1 compatible tasks using the Task Scheduler V2 API
-# It is designed to be a binary compatible API to puppet/util/windows/taskscheduler.rb but
-# will only surface the features used by the Puppet scheduledtask provider
-#
 require_relative './taskscheduler2'
 require_relative './trigger'
 
@@ -36,7 +33,7 @@ class TaskScheduler2Task
   def enum
     @tasksched.enum_task_names(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::ROOT_FOLDER,
       include_child_folders: false,
-      include_compatibility: [PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_AT, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_V1]).map do |item|
+      include_compatibility: [PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_V2]).map do |item|
         @tasksched.task_name_from_task_path(item) + '.job'
     end
   end
@@ -165,7 +162,7 @@ class TaskScheduler2Task
     @task = nil
     @task_password = nil
 
-    @tasksched.set_compatibility(@definition, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_V1)
+    @tasksched.set_compatibility(@definition, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_V2)
 
     Trigger::V2.append_v1trigger(@definition, task_trigger)
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
@@ -28,13 +28,11 @@ class TaskScheduler2Task
 
   # Returns an array of scheduled task names.
   #
-  # Emulates V1 tasks by appending the '.job' suffix
-  #
   def enum
     @tasksched.enum_task_names(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::ROOT_FOLDER,
       include_child_folders: false,
       include_compatibility: [PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_V2]).map do |item|
-        @tasksched.task_name_from_task_path(item) + '.job'
+        @tasksched.task_name_from_task_path(item)
     end
   end
   alias :tasks :enum
@@ -221,7 +219,7 @@ class TaskScheduler2Task
   # Returns whether or not the scheduled task exists.
   def exists?(job_name)
     # task name comparison is case insensitive
-    enum.any? { |name| name.casecmp(job_name + '.job') == 0 }
+    enum.any? { |name| name.casecmp(job_name) == 0 }
   end
 
   private

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -259,6 +259,7 @@ module Trigger
       end
 
       # Values for all Trigger Types
+      iTrigger.RandomDelay         = "PT#{v1trigger['random_minutes_interval']}M" unless v1trigger['random_minutes_interval'].nil?   || v1trigger['random_minutes_interval'].zero?
       iTrigger.Repetition.Interval = "PT#{v1trigger['minutes_interval']}M" unless v1trigger['minutes_interval'].nil? || v1trigger['minutes_interval'].zero?
       iTrigger.Repetition.Duration = "PT#{v1trigger['minutes_duration']}M" unless v1trigger['minutes_duration'].nil? || v1trigger['minutes_duration'].zero?
       iTrigger.StartBoundary = Trigger.iso8601_datetime(v1trigger['start_year'],

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task_spec.rb
@@ -46,6 +46,7 @@ def triggers
       'trigger_type'            => :TASK_TIME_TRIGGER_ONCE,
     }),
     defaults.merge({
+      'random_minutes_interval' => 0,
       'type'                    => { 'days_interval' => 1 },
       'trigger_type'            => :TASK_TIME_TRIGGER_DAILY,
     }),
@@ -107,7 +108,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2Task", :if => Puppet
         expect(subject.trigger_count).to eq(1)
         expect(subject.trigger(0)['trigger_type']).to eq(trigger['trigger_type'])
         expect(subject.trigger(0)['type']).to eq(trigger['type']) if trigger['type']
-        #expect(task.Definition.Triggers.Item(1).RandomDelay).to eq("PT#{trigger['random_minutes_interval']}M") if trigger['random_minutes_interval']
+        expect(task.Definition.Triggers.Item(1).RandomDelay).to eq("PT#{trigger['random_minutes_interval']}M") if trigger['random_minutes_interval'] && trigger['random_minutes_interval'] > 0
       end
     end
   end

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task_spec.rb
@@ -1,0 +1,182 @@
+
+#!/usr/bin/env ruby
+require 'spec_helper'
+
+require 'puppet_x/puppetlabs/scheduled_task/taskscheduler2_task' if Puppet.features.microsoft_windows?
+
+RSpec::Matchers.define :be_same_as_powershell_command do |ps_cmd|
+  define_method :run_ps do |cmd|
+    full_cmd = "powershell.exe -NoLogo -NoProfile -NonInteractive -Command \"#{cmd}\""
+
+    result = `#{full_cmd}`
+
+    result.strip
+  end
+
+  match do |actual|
+    from_ps = run_ps(ps_cmd)
+    actual.to_s == from_ps
+  end
+
+  failure_message do |actual|
+    "expected that #{actual} would match #{run_ps(ps_cmd)} from PowerShell command #{ps_cmd}"
+  end
+end
+
+def triggers
+  now = Time.now
+
+  defaults = {
+    'end_day'                 => 0,
+    'end_year'                => 0,
+    'minutes_interval'        => 0,
+    'end_month'               => 0,
+    'minutes_duration'        => 0,
+    'start_year'              => now.year,
+    'start_month'             => now.month,
+    'start_day'               => now.day,
+    'start_hour'              => now.hour,
+    'start_minute'            => now.min,
+  }
+
+  [
+    # dummy time trigger
+    defaults.merge({
+      'random_minutes_interval' => 1,
+      'trigger_type'            => :TASK_TIME_TRIGGER_ONCE,
+    }),
+    defaults.merge({
+      'type'                    => { 'days_interval' => 1 },
+      'trigger_type'            => :TASK_TIME_TRIGGER_DAILY,
+    }),
+    defaults.merge({
+      'type'         => {
+        'weeks_interval' => 1,
+        'days_of_week'   => Win32::TaskScheduler::MONDAY,
+      },
+      'trigger_type'            => :TASK_TIME_TRIGGER_WEEKLY,
+    }),
+    defaults.merge({
+      'type'         => {
+        'months' => Win32::TaskScheduler::JANUARY,
+        # Bitwise mask, reference on MSDN:
+        # https://msdn.microsoft.com/en-us/library/windows/desktop/aa380735(v=vs.85).aspx
+        # 8192 is for the 14th
+        'days'   => 8192,
+      },
+      'trigger_type'            => :TASK_TIME_TRIGGER_MONTHLYDATE,
+    }),
+    defaults.merge({
+      'type'         => {
+        'months'       => Win32::TaskScheduler::JANUARY,
+        'weeks'        => Win32::TaskScheduler::FIRST_WEEK,
+        'days_of_week' => Win32::TaskScheduler::MONDAY,
+      },
+      'trigger_type'            => :TASK_TIME_TRIGGER_MONTHLYDOW,
+    })
+  ]
+end
+
+# These integration tests use V2 API tasks and make sure they save
+# and read back correctly
+describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2Task", :if => Puppet.features.microsoft_windows? do
+  let(:subject) { PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2Task.new() }
+
+  triggers.each do |trigger|
+    context "should be able to create a #{trigger['trigger_type']} trigger" do
+      before(:each) do
+        @task_name = 'puppet_task_' + SecureRandom.uuid.to_s
+
+        task = subject.class.new(@task_name, trigger)
+        task.application_name = 'cmd.exe'
+        task.parameters = '/c exit 0'
+        task.save
+      end
+
+      after(:each) do
+        subject.delete(@task_name) if subject.exists?(@task_name)
+      end
+
+      it 'and should return the same properties as those set' do
+        expect(subject.exists?(@task_name)).to be true
+
+        task = subject.activate(@task_name)
+
+        expect(subject.parameters).to eq('/c exit 0')
+        expect(subject.application_name).to eq('cmd.exe')
+        expect(subject.trigger_count).to eq(1)
+        expect(subject.trigger(0)['trigger_type']).to eq(trigger['trigger_type'])
+        expect(subject.trigger(0)['type']).to eq(trigger['type']) if trigger['type']
+        #expect(task.Definition.Triggers.Item(1).RandomDelay).to eq("PT#{trigger['random_minutes_interval']}M") if trigger['random_minutes_interval']
+      end
+    end
+  end
+
+  context "When managing a task" do
+    before(:each) do
+      @task_name = 'puppet_task_' + SecureRandom.uuid.to_s
+      task = subject.class.new(@task_name, triggers[0])
+      task.application_name = 'cmd.exe'
+      task.parameters = '/c exit 0'
+      task.save
+    end
+
+    after(:each) do
+      subject.delete(@task_name) if subject.exists?(@task_name)
+    end
+
+    it 'should be able to determine if the task exists or not' do
+      bad_task_name = SecureRandom.uuid.to_s
+      expect(subject.exists?(@task_name)).to be(true)
+      expect(subject.exists?(bad_task_name)).to be(false)
+    end
+
+    it 'should able to update a trigger' do
+      new_trigger = triggers[0].merge({
+        'start_year'              => 2112,
+        'start_month'             => 12,
+        'start_day'               => 12,
+      })
+
+      task = subject.activate(@task_name)
+      expect(subject.delete_trigger(0)).to be(1)
+      subject.trigger = new_trigger
+      subject.save
+      ps_cmd = '([string]((Get-ScheduledTask | ? { $_.TaskName -eq \'' + @task_name + '\' }).Triggers.StartBoundary) -split \'T\')[0]'
+      expect('2112-12-12').to be_same_as_powershell_command(ps_cmd)
+    end
+
+    it 'should be able to update a command' do
+      new_application_name = 'notepad.exe'
+      ps_cmd = '[string]((Get-ScheduledTask | ? { $_.TaskName -eq \'' + @task_name + '\' }).Actions[0].Execute)'
+      task = subject.activate(@task_name)
+
+      expect('cmd.exe').to be_same_as_powershell_command(ps_cmd)
+      subject.application_name = new_application_name
+      subject.save
+      expect(new_application_name).to be_same_as_powershell_command(ps_cmd)
+    end
+
+    it 'should be able to update command parameters' do
+      new_parameters = '/nonsense /utter /nonsense'
+      ps_cmd = '[string]((Get-ScheduledTask | ? { $_.TaskName -eq \'' + @task_name + '\' }).Actions[0].Arguments)'
+      task = subject.activate(@task_name)
+
+      expect('/c exit 0').to be_same_as_powershell_command(ps_cmd)
+      subject.parameters = new_parameters
+      subject.save
+      expect(new_parameters).to be_same_as_powershell_command(ps_cmd)
+    end
+
+    it 'should be able to update the working directory' do
+      new_working_directory = 'C:\Somewhere'
+      ps_cmd = '[string]((Get-ScheduledTask | ? { $_.TaskName -eq \'' + @task_name + '\' }).Actions[0].WorkingDirectory)'
+      task = subject.activate(@task_name)
+
+      expect('').to be_same_as_powershell_command(ps_cmd)
+      subject.working_directory = new_working_directory
+      subject.save
+      expect(new_working_directory).to be_same_as_powershell_command(ps_cmd)
+    end
+  end
+end


### PR DESCRIPTION
These commits add a V2-only helper by cloning and updating the adapter. It adds integration tests for the new helper and strips away pieces of the helper which are for V1 tasks.

It is _out of scope_ to wire this helper up to the provider or otherwise alter the type/provider for this helper.