### PR TITLE
Test explicit json dep on 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,7 @@ group :system_tests do
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
-gem 'json', '>= 0'
+gem 'json'
 
 # Only explicitly specify Facter/Hiera if a version has been specified.
 # Otherwise it can lead to strange bundler behavior. If you are seeing weird

--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ group :system_tests do
   gem "master_manipulator",                                                      :require => false
 end
 
-gem 'json', '>= 0'
+gem 'json'
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
 
 # Only explicitly specify Facter/Hiera if a version has been specified.

--- a/Gemfile
+++ b/Gemfile
@@ -65,7 +65,6 @@ group :system_tests do
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
-gem 'json'
 
 # Only explicitly specify Facter/Hiera if a version has been specified.
 # Otherwise it can lead to strange bundler behavior. If you are seeing weird

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :system_tests do
   gem "master_manipulator",                                                      :require => false
 end
 
+gem 'json', '>= 0'
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
 
 # Only explicitly specify Facter/Hiera if a version has been specified.

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :system_tests do
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
+gem 'json', '>= 0'
 
 # Only explicitly specify Facter/Hiera if a version has been specified.
 # Otherwise it can lead to strange bundler behavior. If you are seeing weird

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
     ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"'
     ruby -e 'require \"json\"; puts \"default json version: #{JSON::VERSION}\"'
     gem list json
-- bundle install --jobs 4 --retry 2 --without system_tests
+- bundle install --jobs 4 --retry 2 --without system_tests --path .bundle/gems
 - type Gemfile.lock
 build: off
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ install:
     ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"'
     ruby -e 'require \"json\"; puts \"default json version: #{JSON::VERSION}\"'
     gem list json
+    gem env
 - bundle install --jobs 4 --retry 2 --without system_tests --path .bundle/gems
 - type Gemfile.lock
 build: off
@@ -40,6 +41,7 @@ test_script:
       bundle exec ruby -e 'require \"json\"; puts \"bundled json version: #{JSON::VERSION}\"'
       gem list
       bundle exec gem list
+      bundle exec gem env
       bundle show json
   - cmd: |
       bundle exec rake spec SPEC_OPTS='--format documentation'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ install:
     gem list openssl
     ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"'
     ruby -e 'require \"json\"; puts \"default json version: #{JSON::VERSION}\"'
+    gem list json
 - bundle install --jobs 4 --retry 2 --without system_tests
 - type Gemfile.lock
 build: off
@@ -37,6 +38,9 @@ test_script:
       ruby -v
       ruby -e 'require \"json\"; puts \"system json version: #{JSON::VERSION}\"'
       bundle exec ruby -e 'require \"json\"; puts \"bundled json version: #{JSON::VERSION}\"'
+      gem list
+      bundle exec gem list
+      bundle show json
   - cmd: |
       bundle exec rake spec SPEC_OPTS='--format documentation'
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,13 +27,18 @@ install:
 - ps: |
     gem list openssl
     ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"'
+    ruby -e 'require \"json\"; puts \"default json version: #{JSON::VERSION}\"'
 - bundle install --jobs 4 --retry 2 --without system_tests
 - type Gemfile.lock
 build: off
 test_script:
-- bundle exec puppet -V
-- ruby -v
-- bundle exec rake spec SPEC_OPTS='--format documentation'
+  - ps: |
+      bundle exec puppet -V
+      ruby -v
+      ruby -e 'require \"json\"; puts \"system json version: #{JSON::VERSION}\"'
+      bundle exec ruby -e 'require \"json\"; puts \"bundled json version: #{JSON::VERSION}\"'
+  - cmd: |
+      bundle exec rake spec SPEC_OPTS='--format documentation'
 notifications:
 - provider: Email
   to:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,6 +43,7 @@ test_script:
       bundle exec gem list
       bundle exec gem env
       bundle show json
+      bundle env
   - cmd: |
       bundle exec rake spec SPEC_OPTS='--format documentation'
 notifications:


### PR DESCRIPTION
This is merely a test to evaluate what happens when json is required explicitly.

It *should* use the system gem, not install a new native `2.1.0` gem.