### PR TITLE
(MODULES-6526) Add compatibility in task type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Initial unsupported release of the scheduled_task module.  Adapts the Puppet sch
 ### Added
 
 - Added V2 provider for the V1 Puppet type ([MODULES-6264](https://tickets.puppetlabs.com/browse/MODULES-6264), [MODULES-6266](https://tickets.puppetlabs.com/browse/MODULES-6266))
+- Added `compatibility` flag, allowing users to specify which version of Scheduled Tasks the task should be compatible with ([MODULES-6526](https://tickets.puppetlabs.com/browse/MODULES-6526))
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ The password for the user specified in the 'user' attribute.
 This is only used if specifying a user other than 'SYSTEM'.
 This parameter will not be used to determine if a scheduled task is in sync or not because there is no way to retrieve the password used to set the account information for a task.
 
+##### `compatibility`
+
+The compatibility level associated with the task.
+May currently only be set to 1 for compatibility with tasks on a Windows XP or Windows Server 2003 computer.
+
 ##### `provider`
 
 The specific backend to use for this scheduled_task resource.

--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -62,6 +62,10 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
     account
   end
 
+  def compatibility
+    task.compatibility
+  end
+
   def trigger
     return @triggers if @triggers
 

--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -83,6 +83,15 @@ Puppet::Type.newtype(:scheduled_task) do
       to determine if a scheduled task is in sync or not."
   end
 
+  newproperty(:compatibility) do
+    desc "The compatibility level associated with the task. May currently only
+      be set to 1 for compatibility with tasks on a Windows XP or Windows Server
+      2003 computer."
+
+    newvalue(1)
+    defaultto(1)
+  end
+
   newproperty(:trigger, :array_matching => :all) do
     desc <<-'EOT'
       One or more triggers defining when the task should run. A single trigger is

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
@@ -176,6 +176,10 @@ class TaskScheduler2Task
     @tasksched.trigger_count(@definition)
   end
 
+  def compatibility
+    @tasksched.compatibility(@definition)
+  end
+
   # Deletes the trigger at the specified index.
   #
   def delete_trigger(index)

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -175,6 +175,10 @@ class TaskScheduler2V1Task
   end
   alias :new_task :new_work_item
 
+  def compatibility
+    @tasksched.compatibility(@definition)
+  end
+
   # Returns the number of triggers associated with the active task.
   #
   def trigger_count

--- a/spec/unit/puppet/type/scheduled_task_spec.rb
+++ b/spec/unit/puppet/type/scheduled_task_spec.rb
@@ -108,6 +108,29 @@ describe Puppet::Type.type(:scheduled_task), :if => Puppet.features.microsoft_wi
     end
   end
 
+  describe 'when setting the compatibility' do
+    it 'should allow 1' do
+      expect(described_class.new(
+        :title        => 'Foo',
+        :command      => 'C:\Windows\System32\notepad.exe',
+        :compatibility => 1,
+      )[:compatibility]).to eq(:'1')
+    end
+
+    it 'should not allow 2' do
+      expect {
+        described_class.new(
+          :name         => 'Foo',
+          :command      => 'C:\Windows\System32\notepad.exe',
+          :compatibility => 2
+        )
+      }.to raise_error(
+        Puppet::ResourceError,
+        /Parameter compatibility failed on Scheduled_task\[Foo\]: Invalid value 2\. Valid values are 1\./
+      )
+    end
+  end
+
   describe 'when setting the trigger' do
     it 'should delegate to the provider to validate the trigger' do
       described_class.defaultprovider.any_instance.expects(:validate_trigger).returns(true)


### PR DESCRIPTION
 - Report on the compatibility level of tasks enumerated from the
   system.

   This requires adding a value to the scheduled_task type named
   compatibility. Based on how the provider works, it currently only
   enumerates v1 tasks, and therefore only returns 1.

   Since the property may now also be set in a manifest, limit the
   value to 1 so that it cannot be set improperly. Default the value
   to 1 to preserve backward compatibility.

   `puppet resource` will now emit the value as well

   A future commit will add compatibility versioning for V2 when
   that helper is wired up.