### PR TITLE
(MODULES-6526) Add setter for compatibility

### DIFF
--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -164,6 +164,10 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
     end
   end
 
+  def compatibility=(value)
+    task.compatibility = value
+  end
+
   def trigger=(value)
     desired_triggers = value.is_a?(Array) ? value : [value]
     current_triggers = trigger.is_a?(Array) ? trigger : [trigger]

--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -90,6 +90,14 @@ Puppet::Type.newtype(:scheduled_task) do
 
     newvalue(1)
     defaultto(1)
+
+    validate do |value|
+      raise Puppet::Error.new(_("must be a number")) unless value.is_a?(Integer)
+      super(value)
+    end
+
+    # override default munging of newvalue() to symbol, treating input as number
+    munge { |value| value }
   end
 
   newproperty(:trigger, :array_matching => :all) do

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
@@ -180,6 +180,10 @@ class TaskScheduler2Task
     @tasksched.compatibility(@definition)
   end
 
+  def compatibility=(value)
+    @tasksched.set_compatibility(@definition, value)
+  end
+
   # Deletes the trigger at the specified index.
   #
   def delete_trigger(index)

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -179,6 +179,10 @@ class TaskScheduler2V1Task
     @tasksched.compatibility(@definition)
   end
 
+  def compatibility=(value)
+    @tasksched.set_compatibility(@definition, value)
+  end
+
   # Returns the number of triggers associated with the active task.
   #
   def trigger_count

--- a/spec/unit/puppet/type/scheduled_task_spec.rb
+++ b/spec/unit/puppet/type/scheduled_task_spec.rb
@@ -114,7 +114,20 @@ describe Puppet::Type.type(:scheduled_task), :if => Puppet.features.microsoft_wi
         :title        => 'Foo',
         :command      => 'C:\Windows\System32\notepad.exe',
         :compatibility => 1,
-      )[:compatibility]).to eq(:'1')
+      )[:compatibility]).to eq(1)
+    end
+
+    it 'should not allow the string value "1"' do
+      expect {
+        described_class.new(
+          :name         => 'Foo',
+          :command      => 'C:\Windows\System32\notepad.exe',
+          :compatibility => "1"
+        )
+      }.to raise_error(
+        Puppet::ResourceError,
+        /Parameter compatibility failed on Scheduled_task\[Foo\]: must be a number/
+      )
     end
 
     it 'should not allow 2' do


### PR DESCRIPTION
Prior to this commit the code was added to enable
users to specify a compatibility version to create
a task. Unfortunately, there was no testing for
verifying idempotency. When run against an existing
task the resource would fail because it can not
handle the compatibility property.  This commit
ensures that the compatibility property is settable.