### PR TITLE
(MODULES-6526) Confine compatibility to a feature

### DIFF
--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -10,6 +10,8 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
   defaultfor :operatingsystem => :windows
   confine    :operatingsystem => :windows
 
+  has_feature :compatibility
+
   def self.instances
     PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task.new.tasks.collect do |job_file|
       job_title = File.basename(job_file, '.job')

--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -7,6 +7,10 @@ Puppet::Type.newtype(:scheduled_task) do
     except `name`, `command`, and `trigger` are optional; see the description
     of the `trigger` attribute for details on setting schedules."
 
+  feature :compatibility, "The provider accepts compatibility to be
+    set for the given task.",
+    :methods => [:compatibility, :compatibility=]
+
   ensurable
 
   newproperty(:enabled) do
@@ -83,7 +87,7 @@ Puppet::Type.newtype(:scheduled_task) do
       to determine if a scheduled task is in sync or not."
   end
 
-  newproperty(:compatibility) do
+  newproperty(:compatibility, :required_features=>:compatibility) do
     desc "The compatibility level associated with the task. May currently only
       be set to 1 for compatibility with tasks on a Windows XP or Windows Server
       2003 computer."


### PR DESCRIPTION
Prior to this commit any calls to the win32 legacy provider after
the introduction of the compatibility setting cause a run to blow
up because that provider does not have a way to manage compatibility.

This commit adds a feature, `:compatibility`, and limits the methods
for compatibility setting and getting to that feature.  Note that this
method will cause the legacy provider and any provider that does not
support the feature to silently ignore compatibility if passed in a
manifest.  It will not error but it also won't do anything.

If swapping between providers, this can probably cause some strange
behavior.  All net-new features and properties for this module will
probably need to be added this way to prevent explosions in the
legacy provider.

The added acceptance test is a simple copy-change and is not robust.
A future ticket and PR should ensure that the acceptance suite does
a bit more to test against both providers.