### PR TITLE
(MODULES-6895) Additional Trigger conversion bugfixes and refactorings

### DIFF
--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -73,11 +73,11 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
     task.trigger_count.times do |i|
       trigger = begin
                   task.trigger(i)
-                rescue Win32::TaskScheduler::Error
-                  # Win32::TaskScheduler can't handle all of the
-                  # trigger types Windows uses, so we need to skip the
-                  # unhandled types to prevent "puppet resource" from
-                  # blowing up.
+                rescue ArgumentError
+                  raise unless $!.message.start_with?('Unknown trigger type')
+                  # Code can't handle all of the trigger types Windows uses yet,
+                  # so we need to skip the unhandled types to prevent "puppet resource"
+                  # from blowing up.
                   nil
                 end
       next unless trigger && PuppetX::PuppetLabs::ScheduledTask::Trigger::V2::V1_TYPE_MAP.keys.include?(trigger['trigger_type'])

--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -222,17 +222,12 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
   end
 
   def validate_trigger(value)
-    value = [value] unless value.is_a?(Array)
-
-    value.each do |t|
-      if t.has_key?('index')
-        self.fail "'index' is read-only on scheduled_task triggers and should be removed ('index' is usually provided in puppet resource scheduled_task)."
+    [value].flatten.each do |t|
+      %w[index enabled].each do |key|
+        if t.key?(key)
+          self.fail "'#{key}' is read-only on scheduled_task triggers and should be removed ('#{key}' is usually provided in puppet resource scheduled_task)."
+        end
       end
-
-      if t.has_key?('enabled')
-        self.fail "'enabled' is read-only on scheduled_task triggers and should be removed ('enabled' is usually provided in puppet resource scheduled_task)."
-      end
-
       PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.from_manifest_hash(t)
     end
 

--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -157,11 +157,8 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
     end
 
     needed_triggers.each do |trigger_hash|
-      # Even though this is an assignment, the API for
-      # Win32::TaskScheduler ends up appending this trigger to the
-      # list of triggers for the task, while #add_trigger is only able
-      # to replace existing triggers. *shrug*
-      task.trigger = PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.from_manifest_hash(trigger_hash)
+      v1trigger = PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.from_manifest_hash(trigger_hash)
+      task.append_trigger(v1trigger)
     end
   end
 

--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -68,16 +68,11 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
 
   def trigger
     @triggers ||= task.trigger_count.times.map do |i|
-      begin
-        v1trigger = task.trigger(i)
-        PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.to_manifest_hash(v1trigger).merge({'index' => i})
-      rescue ArgumentError
-        raise unless $!.message.start_with?('Unknown trigger type')
-        # Code can't handle all of the trigger types Windows uses yet,
-        # so we need to skip the unhandled types to prevent "puppet resource"
-        # from blowing up.
-        nil
-      end
+      v1trigger = task.trigger(i)
+      # nil trigger definitions are unsupported ITrigger types
+      next if v1trigger.nil?
+      index = { 'index' => i }
+      PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.to_manifest_hash(v1trigger).merge(index)
     end.compact
   end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
@@ -201,10 +201,9 @@ class TaskScheduler2Task
       Trigger::V1.from_iTrigger(trigger_object)
   end
 
-  # Sets the trigger for the currently active task.
+  # Appends a new trigger for the currently active task.
   #
-  # Note - This method name is a mis-nomer. It's actually appending a newly created trigger to the trigger collection.
-  def trigger=(v1trigger)
+  def append_trigger(v1trigger)
     Trigger::V2.append_v1trigger(@definition, v1trigger)
   end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
@@ -196,7 +196,9 @@ class TaskScheduler2Task
     # The older V1 API uses a starting index of zero, wherease the V2 API uses one.
     # Need to increment by one to maintain the same behavior
     trigger_object = @tasksched.trigger(@definition, index + 1)
-    trigger_object.nil? ? nil : Trigger::V1.from_iTrigger(trigger_object)
+    trigger_object.nil? || Trigger::V2::V1_TYPE_MAP.key(trigger_object.Type).nil? ?
+      nil :
+      Trigger::V1.from_iTrigger(trigger_object)
   end
 
   # Sets the trigger for the currently active task.

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -206,10 +206,9 @@ class TaskScheduler2V1Task
       Trigger::V1.from_iTrigger(trigger_object)
   end
 
-  # Sets the trigger for the currently active task.
+  # Appends a new trigger for the currently active task.
   #
-  # Note - This method name is a mis-nomer. It's actually appending a newly created trigger to the trigger collection.
-  def trigger=(v1trigger)
+  def append_trigger(v1trigger)
     Trigger::V2.append_v1trigger(@definition, v1trigger)
   end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -201,7 +201,9 @@ class TaskScheduler2V1Task
     # The older V1 API uses a starting index of zero, wherease the V2 API uses one.
     # Need to increment by one to maintain the same behavior
     trigger_object = @tasksched.trigger(@definition, index + 1)
-    trigger_object.nil? ? nil : Trigger::V1.from_iTrigger(trigger_object)
+    trigger_object.nil? || Trigger::V2::V1_TYPE_MAP.key(trigger_object.Type).nil? ?
+      nil :
+      Trigger::V1.from_iTrigger(trigger_object)
   end
 
   # Sets the trigger for the currently active task.

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -405,7 +405,10 @@ module Trigger
           'weeks_interval' => 1
         }
       when 'monthly'
-        { 'months' => Month.indexes_to_bitmask((1..12).to_a) }
+        {
+          'months' => Month.indexes_to_bitmask((1..12).to_a),
+          'days' => 0
+        }
       end
     end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -337,22 +337,23 @@ module Trigger
     # iTrigger is a COM ITrigger instance
     def self.from_iTrigger(iTrigger)
       trigger_flags = 0
-      trigger_flags = trigger_flags | Flag::TASK_TRIGGER_FLAG_HAS_END_DATE unless iTrigger.Endboundary.empty?
+      trigger_flags = trigger_flags | Flag::TASK_TRIGGER_FLAG_HAS_END_DATE unless iTrigger.EndBoundary.empty?
       # There is no corresponding setting for the V1 flag TASK_TRIGGER_FLAG_KILL_AT_DURATION_END
       trigger_flags = trigger_flags | Flag::TASK_TRIGGER_FLAG_DISABLED unless iTrigger.Enabled
 
+      # StartBoundary and EndBoundary may be empty strings per V2 API
       start_boundary = Trigger.string_to_date(iTrigger.StartBoundary)
       end_boundary = Trigger.string_to_date(iTrigger.EndBoundary)
 
       v1trigger = {
-        'start_year'              => start_boundary.year,
-        'start_month'             => start_boundary.month,
-        'start_day'               => start_boundary.day,
+        'start_year'              => start_boundary ? start_boundary.year : 0,
+        'start_month'             => start_boundary ? start_boundary.month : 0,
+        'start_day'               => start_boundary ? start_boundary.day : 0,
         'end_year'                => end_boundary ? end_boundary.year : 0,
         'end_month'               => end_boundary ? end_boundary.month : 0,
         'end_day'                 => end_boundary ? end_boundary.day : 0,
-        'start_hour'              => start_boundary.hour,
-        'start_minute'            => start_boundary.minute,
+        'start_hour'              => start_boundary ? start_boundary.hour : 0,
+        'start_minute'            => start_boundary ? start_boundary.minute : 0,
         'minutes_duration'        => Duration.to_minutes(iTrigger.Repetition.Duration),
         'minutes_interval'        => Duration.to_minutes(iTrigger.Repetition.Interval),
         'flags'                   => trigger_flags,

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task_spec.rb
@@ -138,7 +138,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2Task", :if => Puppet
 
       task = subject.activate(@task_name)
       expect(subject.delete_trigger(0)).to be(1)
-      subject.trigger = new_trigger
+      subject.append_trigger(new_trigger)
       subject.save
       ps_cmd = '([string]((Get-ScheduledTask | ? { $_.TaskName -eq \'' + @task_name + '\' }).Triggers.StartBoundary) -split \'T\')[0]'
       expect('2112-12-12').to be_same_as_powershell_command(ps_cmd)

--- a/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -474,8 +474,10 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
           'start_minute' => 21,
           'flags'        => 0,
         })
+        @error_class = task_provider == :win32_taskscheduler ?
+          Win32::TaskScheduler::Error : ArgumentError
         @mock_task.expects(:trigger).with(1).raises(
-          Win32::TaskScheduler::Error.new('Unhandled trigger type!')
+          @error_class.new('Unknown trigger type')
         )
         @mock_task.expects(:trigger).with(2).returns({
           'trigger_type' => :TASK_TIME_TRIGGER_ONCE,

--- a/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -1802,11 +1802,13 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
         resource.provider.stubs(:trigger).returns(current_triggers)
         if resource.provider.is_a?(Puppet::Type::Scheduled_task::ProviderWin32_taskscheduler)
           translater = resource.provider.method(:translate_hash_to_trigger)
+          expected_method = :trigger=
         else
           translater = PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.method(:from_manifest_hash)
+          expected_method = :append_trigger
         end
-        @mock_task.expects(:trigger=).with(translater.call(@trigger[1]))
-        @mock_task.expects(:trigger=).with(translater.call(@trigger[2]))
+        @mock_task.expects(expected_method).with(translater.call(@trigger[1]))
+        @mock_task.expects(expected_method).with(translater.call(@trigger[2]))
 
         resource.provider.trigger = @trigger
       end

--- a/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -474,11 +474,14 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
           'start_minute' => 21,
           'flags'        => 0,
         })
-        @error_class = task_provider == :win32_taskscheduler ?
-          Win32::TaskScheduler::Error : ArgumentError
-        @mock_task.expects(:trigger).with(1).raises(
-          @error_class.new('Unknown trigger type')
-        )
+        if task_provider == :win32_taskscheduler
+          @mock_task.expects(:trigger).with(1).raises(
+            Win32::TaskScheduler::Error.new('Unknown trigger type')
+          )
+        else
+          @mock_task.expects(:trigger).with(1).returns(nil)
+        end
+
         @mock_task.expects(:trigger).with(2).returns({
           'trigger_type' => :TASK_TIME_TRIGGER_ONCE,
           'start_year'   => 2013,
@@ -522,9 +525,11 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
           'start_minute' => 21,
           'flags'        => 0,
         })
-        @mock_task.expects(:trigger).with(1).returns({
-          'trigger_type' => Win32::TaskScheduler::TASK_EVENT_TRIGGER_AT_LOGON,
-        })
+        @trigger1 = task_provider == :win32_taskscheduler ?
+          { 'trigger_type' => Win32::TaskScheduler::TASK_EVENT_TRIGGER_AT_LOGON, } :
+          nil
+        @mock_task.expects(:trigger).with(1).returns(@trigger1)
+
         @mock_task.expects(:trigger).with(2).returns({
           'trigger_type' => :TASK_TIME_TRIGGER_ONCE,
           'start_year'   => 2013,

--- a/spec/unit/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -166,25 +166,25 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger::V1 do
     }.freeze
 
     [
-      { :ole_type => 'ITimeTrigger',       :Type => V2::Type::TASK_TRIGGER_TIME,
+      { :Type => V2::Type::TASK_TRIGGER_TIME,
         :RandomDelay  => '',
        },
-      { :ole_type => 'IDailyTrigger',      :Type => V2::Type::TASK_TRIGGER_DAILY,
+      { :Type => V2::Type::TASK_TRIGGER_DAILY,
         :DaysInterval => 1,
         :RandomDelay  => '',
       },
-      { :ole_type => 'IWeeklyTrigger',     :Type => V2::Type::TASK_TRIGGER_WEEKLY,
+      { :Type => V2::Type::TASK_TRIGGER_WEEKLY,
         :DaysOfWeek => 0,
         :WeeksInterval => 1,
         :RandomDelay  => '',
       },
-      { :ole_type => 'IMonthlyTrigger',    :Type => V2::Type::TASK_TRIGGER_MONTHLY,
+      { :Type => V2::Type::TASK_TRIGGER_MONTHLY,
         :DaysOfMonth => 0,
         :MonthsOfYear => 4095,
         :RunOnLastDayOfMonth => false,
         :RandomDelay  => '',
       },
-      { :ole_type => 'IMonthlyDOWTrigger', :Type => V2::Type::TASK_TRIGGER_MONTHLYDOW,
+      { :Type => V2::Type::TASK_TRIGGER_MONTHLYDOW,
         :DaysOfWeek => 1,
         :WeeksOfMonth => 1,
         :MonthsOfYear => 1,
@@ -198,6 +198,21 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger::V1 do
         iTrigger[:Repetition] = stub(iTrigger[:Repetition])
         iTrigger = stub(iTrigger)
         expect(subject.class.from_iTrigger(iTrigger)).to_not be_nil
+      end
+    end
+
+    [
+      { :ole_type => 'IBootTrigger', :Type => V2::Type::TASK_TRIGGER_BOOT, },
+      { :ole_type => 'IIdleTrigger', :Type => V2::Type::TASK_TRIGGER_IDLE, },
+      { :ole_type => 'IRegistrationTrigger', :Type => V2::Type::TASK_TRIGGER_REGISTRATION, },
+      { :ole_type => 'ILogonTrigger', :Type => V2::Type::TASK_TRIGGER_LOGON, },
+      { :ole_type => 'ISessionStateChangeTrigger', :Type => V2::Type::TASK_TRIGGER_SESSION_STATE_CHANGE, },
+      { :ole_type => 'IEventTrigger', :Type => V2::Type::TASK_TRIGGER_EVENT, },
+    ].each do |trigger_details|
+      it "should fail to convert an #{trigger_details[:ole_type]} instance" do
+        # stub is not usable outside of specs (like in DEFAULT_ITRIGGER_PROPERTIES)
+        iTrigger = stub(DEFAULT_ITRIGGER_PROPERTIES.merge(trigger_details))
+        expect { subject.class.from_iTrigger(iTrigger) }.to raise_error(ArgumentError)
       end
     end
 
@@ -229,7 +244,6 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger::V1 do
       {
         :iTrigger =>
         {
-          :ole_type => 'ITimeTrigger',
           :Type => V2::Type::TASK_TRIGGER_TIME,
           :RandomDelay  => 'P2DT5S', # ignored
         },
@@ -242,7 +256,6 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger::V1 do
       {
         :iTrigger =>
         {
-          :ole_type => 'IDailyTrigger',
           :Type => V2::Type::TASK_TRIGGER_DAILY,
           :DaysInterval => 2,
           :RandomDelay  => 'P2DT5S', # ignored
@@ -256,7 +269,6 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger::V1 do
       {
         :iTrigger =>
         {
-          :ole_type => 'IWeeklyTrigger',
           :Type => V2::Type::TASK_TRIGGER_WEEKLY,
           :DaysOfWeek => 0b1111111,
           :WeeksInterval => 2,
@@ -271,7 +283,6 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger::V1 do
       {
         :iTrigger =>
         {
-          :ole_type => 'IMonthlyTrigger',
           :Type => V2::Type::TASK_TRIGGER_MONTHLY,
           :DaysOfMonth => 0b11111111111111111111111111111111,
           :MonthsOfYear => 1,
@@ -287,7 +298,6 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger::V1 do
       {
         :iTrigger =>
         {
-          :ole_type => 'IMonthlyDOWTrigger',
           :Type => V2::Type::TASK_TRIGGER_MONTHLYDOW,
           :DaysOfWeek => 0b1111111,
           :WeeksOfMonth => 0b11111,

--- a/spec/unit/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -328,6 +328,7 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger::V1 do
       'once',
       'daily',
       'weekly',
+      'monthly',
     ].each do |type|
       it "should convert a default #{type}" do
         v1trigger = subject.class.default_trigger_for(type)


### PR DESCRIPTION
This should be merged prior to #27, partly because some code is being extracted from `taskscheduler_api2` and that code is about to be copied into `win32_taskscheduler`.  Therefore it makes more sense to do this work first, especially given it fixes some critical bugs in converting `ITrigger` back to a V1 internal representation.