### PR TITLE
(MODULES-7026) Ensure timezones other than UTC work

### DIFF
--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -71,8 +71,8 @@ module Trigger
   end
   module_function :string_to_date
 
-  def iso8601_datetime(year, month, day, hour, minute)
-    DateTime.new(year, month, day, hour, minute, 0).iso8601
+  def iso8601_datetime(year, month, day, hour, minute, offset = DateTime.now.offset)
+    DateTime.new(year, month, day, hour, minute, 0, offset).iso8601
   end
   module_function :iso8601_datetime
 

--- a/spec/unit/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -52,11 +52,15 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger do
 
   describe "#iso8601_datetime" do
     [
-      # year, month, day, hour, minute
-      { :input => [2018, 3, 20, 8, 57], :expected => '2018-03-20T08:57:00+00:00' },
-      { :input => [1899, 12, 30, 0, 0], :expected => '1899-12-30T00:00:00+00:00' },
+      # year, month, day, hour, minute with 0 offset specified
+      { :input => [2018, 3, 20, 8, 57, 0], :expected => '2018-03-20T08:57:00+00:00' },
+      { :input => [1899, 12, 30, 0, 0, 0], :expected => '1899-12-30T00:00:00+00:00' },
+      # don't specify timezone, using default offset
+      { :input => [2018, 3, 20, 8, 57], :expected => "2018-03-20T08:57:00#{DateTime.now.zone}" },
+      { :input => [1899, 12, 30, 0, 0], :expected => "1899-12-30T00:00:00#{DateTime.now.zone}" },
     ].each do |value|
       it "should return formatted date string #{value[:expected]} for date components #{value[:input]}" do
+        # The timestring returned is localized so the UTC offset will vary between systems
         expect(subject.iso8601_datetime(*value[:input])).to eq(value[:expected])
       end
     end


### PR DESCRIPTION
Prior to this commit the code for the trigger logic under taskcheduler_api2 only
ever worked for machines whose timezone was set to UTC - it always returned the
datetime string from `iso8691_datetime` with no UTC offset.  This commit updates
that method to return a localized datetime string including the appropriate
offset.

It also updates the unit tests since local offset can vary from system to system.
It does not add any integration or acceptance tests.