### PR TITLE
(WIP) (MODULES-6845) Copy V2 Provider into Win32

### DIFF
--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -1,5 +1,5 @@
 require 'puppet/parameter'
-require_relative '../../../puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task'
+require_relative '../../../puppet_x/puppetlabs/scheduled_task/taskscheduler2_task'
 
 
 Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
@@ -13,7 +13,7 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
   has_feature :compatibility
 
   def self.instances
-    PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task.new.tasks.collect do |job_file|
+    PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2Task.new.tasks.collect do |job_file|
       job_title = File.basename(job_file, '.job')
       new(
         :provider => :taskscheduler_api2,
@@ -23,13 +23,13 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
   end
 
   def exists?
-    PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task.new.exists? resource[:name]
+    PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2Task.new.exists? resource[:name]
   end
 
   def task
     return @task if @task
 
-    @task ||= PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task.new
+    @task ||= PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2Task.new
     @task.activate(resource[:name] + '.job') if exists?
 
     @task
@@ -176,7 +176,7 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
 
   def create
     clear_task
-    @task = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task.new(
+    @task = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2Task.new(
       resource[:name],
       PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.default_trigger_for('once')
     )
@@ -188,7 +188,7 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
   end
 
   def destroy
-    PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task.new.delete(resource[:name] + '.job')
+    PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2Task.new.delete(resource[:name] + '.job')
   end
 
   def flush

--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
   end
 
   def enabled
-    task.flags & Win32::TaskScheduler::DISABLED == 0 ? :true : :false
+    task.flags & PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED == 0 ? :true : :false
   end
 
   def command
@@ -118,9 +118,9 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
 
   def enabled=(value)
     if value == :true
-      task.flags = task.flags & ~Win32::TaskScheduler::DISABLED
+      task.flags = task.flags & ~PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED
     else
-      task.flags = task.flags | Win32::TaskScheduler::DISABLED
+      task.flags = task.flags | PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED
     end
   end
 

--- a/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
+++ b/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
@@ -40,7 +40,7 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
   end
 
   def enabled
-    task.flags & Win32::TaskScheduler::DISABLED == 0 ? :true : :false
+    task.flags & PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED == 0 ? :true : :false
   end
 
   def command
@@ -117,9 +117,9 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
 
   def enabled=(value)
     if value == :true
-      task.flags = task.flags & ~Win32::TaskScheduler::DISABLED
+      task.flags = task.flags & ~PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED
     else
-      task.flags = task.flags | Win32::TaskScheduler::DISABLED
+      task.flags = task.flags | PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED
     end
   end
 

--- a/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
+++ b/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
@@ -1,20 +1,19 @@
 require 'puppet/parameter'
+require_relative '../../../puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task'
 
-if Puppet.features.microsoft_windows?
-  require 'puppet/util/windows/taskscheduler'
-end
 
 Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
-  desc %q{This provider manages scheduled tasks on Windows.}
+  desc "This provider manages scheduled tasks on Windows.
+       This is a technical preview using the newer V2 API interface but
+       still editing V1 compatbile scheduled tasks."
 
   confine    :operatingsystem => :windows
 
-  MINUTES_IN_DAY = 1440
+  has_feature :compatibility
 
   def self.instances
-    Win32::TaskScheduler.new.tasks.collect do |job_file|
+    PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task.new.tasks.collect do |job_file|
       job_title = File.basename(job_file, '.job')
-
       new(
         :provider => :win32_taskscheduler,
         :name     => job_title
@@ -23,13 +22,13 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
   end
 
   def exists?
-    Win32::TaskScheduler.new.exists? resource[:name]
+    PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task.new.exists? resource[:name]
   end
 
   def task
     return @task if @task
 
-    @task ||= Win32::TaskScheduler.new
+    @task ||= PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task.new
     @task.activate(resource[:name] + '.job') if exists?
 
     @task
@@ -62,53 +61,18 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
     account
   end
 
+  def compatibility
+    task.compatibility
+  end
+
   def trigger
-    return @triggers if @triggers
-
-    @triggers   = []
-    task.trigger_count.times do |i|
-      trigger = begin
-                  task.trigger(i)
-                rescue Win32::TaskScheduler::Error
-                  # Win32::TaskScheduler can't handle all of the
-                  # trigger types Windows uses, so we need to skip the
-                  # unhandled types to prevent "puppet resource" from
-                  # blowing up.
-                  nil
-                end
-      next unless trigger and scheduler_trigger_types.include?(trigger['trigger_type'])
-      puppet_trigger = {}
-      case trigger['trigger_type']
-      when Win32::TaskScheduler::TASK_TIME_TRIGGER_DAILY
-        puppet_trigger['schedule'] = 'daily'
-        puppet_trigger['every']    = trigger['type']['days_interval'].to_s
-      when Win32::TaskScheduler::TASK_TIME_TRIGGER_WEEKLY
-        puppet_trigger['schedule']    = 'weekly'
-        puppet_trigger['every']       = trigger['type']['weeks_interval'].to_s
-        puppet_trigger['day_of_week'] = days_of_week_from_bitfield(trigger['type']['days_of_week'])
-      when Win32::TaskScheduler::TASK_TIME_TRIGGER_MONTHLYDATE
-        puppet_trigger['schedule'] = 'monthly'
-        puppet_trigger['months']   = months_from_bitfield(trigger['type']['months'])
-        puppet_trigger['on']       = days_from_bitfield(trigger['type']['days'])
-      when Win32::TaskScheduler::TASK_TIME_TRIGGER_MONTHLYDOW
-        puppet_trigger['schedule']         = 'monthly'
-        puppet_trigger['months']           = months_from_bitfield(trigger['type']['months'])
-        puppet_trigger['which_occurrence'] = occurrence_constant_to_name(trigger['type']['weeks'])
-        puppet_trigger['day_of_week']      = days_of_week_from_bitfield(trigger['type']['days_of_week'])
-      when Win32::TaskScheduler::TASK_TIME_TRIGGER_ONCE
-        puppet_trigger['schedule'] = 'once'
-      end
-      puppet_trigger['start_date'] = self.class.normalized_date("#{trigger['start_year']}-#{trigger['start_month']}-#{trigger['start_day']}")
-      puppet_trigger['start_time'] = self.class.normalized_time("#{trigger['start_hour']}:#{trigger['start_minute']}")
-      puppet_trigger['enabled']    = trigger['flags'] & Win32::TaskScheduler::TASK_TRIGGER_FLAG_DISABLED == 0
-      puppet_trigger['minutes_interval'] = trigger['minutes_interval'] ||= 0
-      puppet_trigger['minutes_duration'] = trigger['minutes_duration'] ||= 0
-      puppet_trigger['index']      = i
-
-      @triggers << puppet_trigger
-    end
-
-    @triggers
+    @triggers ||= task.trigger_count.times.map do |i|
+      v1trigger = task.trigger(i)
+      # nil trigger definitions are unsupported ITrigger types
+      next if v1trigger.nil?
+      index = { 'index' => i }
+      PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.to_manifest_hash(v1trigger).merge(index)
+    end.compact
   end
 
   def user_insync?(current, should)
@@ -159,6 +123,10 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
     end
   end
 
+  def compatibility=(value)
+    task.compatibility = value
+  end
+
   def trigger=(value)
     desired_triggers = value.is_a?(Array) ? value : [value]
     current_triggers = trigger.is_a?(Array) ? trigger : [trigger]
@@ -188,11 +156,8 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
     end
 
     needed_triggers.each do |trigger_hash|
-      # Even though this is an assignment, the API for
-      # Win32::TaskScheduler ends up appending this trigger to the
-      # list of triggers for the task, while #add_trigger is only able
-      # to replace existing triggers. *shrug*
-      task.trigger = translate_hash_to_trigger(trigger_hash)
+      v1trigger = PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.from_manifest_hash(trigger_hash)
+      task.append_trigger(v1trigger)
     end
   end
 
@@ -210,7 +175,10 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
 
   def create
     clear_task
-    @task = Win32::TaskScheduler.new(resource[:name], dummy_time_trigger)
+    @task = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task.new(
+      resource[:name],
+      PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.default_trigger_for('once')
+    )
     self.command = resource[:command]
 
     [:arguments, :working_dir, :enabled, :trigger, :user].each do |prop|
@@ -219,7 +187,7 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
   end
 
   def destroy
-    Win32::TaskScheduler.new.delete(resource[:name] + '.job')
+    PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task.new.delete(resource[:name] + '.job')
   end
 
   def flush
@@ -240,7 +208,7 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
   def triggers_same?(current_trigger, desired_trigger)
     return false unless current_trigger['schedule'] == desired_trigger['schedule']
     return false if current_trigger.has_key?('enabled') && !current_trigger['enabled']
-    return false if translate_hash_to_trigger(desired_trigger)['trigger_type'] != translate_hash_to_trigger(current_trigger)['trigger_type']
+    return false if PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.from_manifest_hash(desired_trigger)['trigger_type'] != PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.from_manifest_hash(current_trigger)['trigger_type']
 
     desired = desired_trigger.dup
     desired['start_date']  ||= current_trigger['start_date']  if current_trigger.has_key?('start_date')
@@ -249,343 +217,19 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
     desired['on']          ||= current_trigger['on']          if current_trigger.has_key?('on')
     desired['day_of_week'] ||= current_trigger['day_of_week'] if current_trigger.has_key?('day_of_week')
 
-    translate_hash_to_trigger(current_trigger) == translate_hash_to_trigger(desired)
-  end
-
-  def self.normalized_date(date_string)
-    date = Date.parse("#{date_string}")
-    "#{date.year}-#{date.month}-#{date.day}"
-  end
-
-  def self.normalized_time(time_string)
-    Time.parse("#{time_string}").strftime('%H:%M')
-  end
-
-  def dummy_time_trigger
-    now = Time.now
-    {
-      'flags'                   => 0,
-      'end_day'                 => 0,
-      'end_year'                => 0,
-      'minutes_interval'        => 0,
-      'end_month'               => 0,
-      'minutes_duration'        => 0,
-      'start_year'              => now.year,
-      'start_month'             => now.month,
-      'start_day'               => now.day,
-      'start_hour'              => now.hour,
-      'start_minute'            => now.min,
-      'trigger_type'            => Win32::TaskScheduler::ONCE,
-    }
-  end
-
-  def translate_hash_to_trigger(puppet_trigger)
-    trigger = dummy_time_trigger
-
-    if puppet_trigger['enabled'] == false
-      trigger['flags'] |= Win32::TaskScheduler::TASK_TRIGGER_FLAG_DISABLED
-    else
-      trigger['flags'] &= ~Win32::TaskScheduler::TASK_TRIGGER_FLAG_DISABLED
-    end
-
-    extra_keys = puppet_trigger.keys.sort - ['index', 'enabled', 'schedule', 'start_date', 'start_time', 'every', 'months', 'on', 'which_occurrence', 'day_of_week', 'minutes_interval', 'minutes_duration']
-    self.fail "Unknown trigger option(s): #{Puppet::Parameter.format_value_for_display(extra_keys)}" unless extra_keys.empty?
-    self.fail "Must specify 'start_time' when defining a trigger" unless puppet_trigger['start_time']
-
-    case puppet_trigger['schedule']
-    when 'daily'
-      trigger['trigger_type'] = Win32::TaskScheduler::DAILY
-      trigger['type'] = {
-        'days_interval' => Integer(puppet_trigger['every'] || 1)
-      }
-    when 'weekly'
-      trigger['trigger_type'] = Win32::TaskScheduler::WEEKLY
-      trigger['type'] = {
-        'weeks_interval' => Integer(puppet_trigger['every'] || 1)
-      }
-
-      trigger['type']['days_of_week'] = if puppet_trigger['day_of_week']
-                                          bitfield_from_days_of_week(puppet_trigger['day_of_week'])
-                                        else
-                                          scheduler_days_of_week.inject(0) {|day_flags,day| day_flags |= day}
-                                        end
-    when 'monthly'
-      trigger['type'] = {
-        'months' => bitfield_from_months(puppet_trigger['months'] || (1..12).to_a),
-      }
-
-      if puppet_trigger.keys.include?('on')
-        if puppet_trigger.has_key?('day_of_week') or puppet_trigger.has_key?('which_occurrence')
-          self.fail "Neither 'day_of_week' nor 'which_occurrence' can be specified when creating a monthly date-based trigger"
-        end
-
-        trigger['trigger_type'] = Win32::TaskScheduler::MONTHLYDATE
-        trigger['type']['days'] = bitfield_from_days(puppet_trigger['on'])
-      elsif puppet_trigger.keys.include?('which_occurrence') or puppet_trigger.keys.include?('day_of_week')
-        self.fail 'which_occurrence cannot be specified as an array' if puppet_trigger['which_occurrence'].is_a?(Array)
-        %w{day_of_week which_occurrence}.each do |field|
-          self.fail "#{field} must be specified when creating a monthly day-of-week based trigger" unless puppet_trigger.has_key?(field)
-        end
-
-        trigger['trigger_type']         = Win32::TaskScheduler::MONTHLYDOW
-        trigger['type']['weeks']        = occurrence_name_to_constant(puppet_trigger['which_occurrence'])
-        trigger['type']['days_of_week'] = bitfield_from_days_of_week(puppet_trigger['day_of_week'])
-      else
-        self.fail "Don't know how to create a 'monthly' schedule with the options: #{puppet_trigger.keys.sort.join(', ')}"
-      end
-    when 'once'
-      self.fail "Must specify 'start_date' when defining a one-time trigger" unless puppet_trigger['start_date']
-
-      trigger['trigger_type'] = Win32::TaskScheduler::ONCE
-    else
-      self.fail "Unknown schedule type: #{puppet_trigger["schedule"].inspect}"
-    end
-
-    integer_interval = -1
-    if puppet_trigger['minutes_interval']
-      integer_interval = Integer(puppet_trigger['minutes_interval'])
-      self.fail 'minutes_interval must be an integer greater or equal to 0' if integer_interval < 0
-      trigger['minutes_interval'] = integer_interval
-    end
-
-    integer_duration = -1
-    if puppet_trigger['minutes_duration']
-      integer_duration = Integer(puppet_trigger['minutes_duration'])
-      self.fail 'minutes_duration must be an integer greater than minutes_interval and equal to or greater than 0' if integer_duration <= integer_interval && integer_duration != 0
-      trigger['minutes_duration'] = integer_duration
-    end
-
-    if integer_interval > 0 && integer_duration == -1
-      integer_duration = MINUTES_IN_DAY
-      trigger['minutes_duration'] = MINUTES_IN_DAY
-    end
-
-    if integer_interval >= integer_duration && integer_interval > 0
-      self.fail 'minutes_interval cannot be set without minutes_duration also being set to a number greater than 0'
-    end
-
-    if start_date = puppet_trigger['start_date']
-      start_date = Date.parse(start_date)
-      self.fail "start_date must be on or after 1753-01-01" unless start_date >= Date.new(1753, 1, 1)
-
-      trigger['start_year']  = start_date.year
-      trigger['start_month'] = start_date.month
-      trigger['start_day']   = start_date.day
-    end
-
-    start_time = Time.parse(puppet_trigger['start_time'])
-    trigger['start_hour']   = start_time.hour
-    trigger['start_minute'] = start_time.min
-
-    trigger
+    PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.from_manifest_hash(current_trigger) == PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.from_manifest_hash(desired)
   end
 
   def validate_trigger(value)
-    value = [value] unless value.is_a?(Array)
-
-    value.each do |t|
-      if t.has_key?('index')
-        self.fail "'index' is read-only on scheduled_task triggers and should be removed ('index' is usually provided in puppet resource scheduled_task)."
+    [value].flatten.each do |t|
+      %w[index enabled].each do |key|
+        if t.key?(key)
+          self.fail "'#{key}' is read-only on scheduled_task triggers and should be removed ('#{key}' is usually provided in puppet resource scheduled_task)."
+        end
       end
-
-      if t.has_key?('enabled')
-        self.fail "'enabled' is read-only on scheduled_task triggers and should be removed ('enabled' is usually provided in puppet resource scheduled_task)."
-      end
-
-      translate_hash_to_trigger(t)
+      PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.from_manifest_hash(t)
     end
 
     true
-  end
-
-  private
-
-  def bitfield_from_months(months)
-    bitfield = 0
-
-    months = [months] unless months.is_a?(Array)
-    months.each do |month|
-      integer_month = Integer(month) rescue nil
-      self.fail 'Month must be specified as an integer in the range 1-12' unless integer_month == month.to_f and integer_month.between?(1,12)
-
-      bitfield |= scheduler_months[integer_month - 1]
-    end
-
-    bitfield
-  end
-
-  def bitfield_from_days(days)
-    bitfield = 0
-
-    days = [days] unless days.is_a?(Array)
-    days.each do |day|
-      # The special "day" of 'last' is represented by day "number"
-      # 32. 'last' has the special meaning of "the last day of the
-      # month", no matter how many days there are in the month.
-      day = 32 if day == 'last'
-
-      integer_day = Integer(day)
-      self.fail "Day must be specified as an integer in the range 1-31, or as 'last'" unless integer_day = day.to_f and integer_day.between?(1,32)
-
-      bitfield |= 1 << integer_day - 1
-    end
-
-    bitfield
-  end
-
-  def bitfield_from_days_of_week(days_of_week)
-    bitfield = 0
-
-    days_of_week = [days_of_week] unless days_of_week.is_a?(Array)
-    days_of_week.each do |day_of_week|
-      bitmask = day_of_week_name_to_constant(day_of_week)
-      self.fail "Days_of_week value #{day_of_week} is invalid. Expected sun, mon, tue, wed, thu, fri or sat." if bitmask.nil?
-      bitfield |= bitmask
-    end
-
-    bitfield
-  end
-
-  def months_from_bitfield(bitfield)
-    months = []
-
-    scheduler_months.each do |month|
-      if bitfield & month != 0
-        months << month_constant_to_number(month)
-      end
-    end
-
-    months
-  end
-
-  def days_from_bitfield(bitfield)
-    days = []
-
-    i = 0
-    while bitfield > 0
-      if bitfield & 1 > 0
-        # Day 32 has the special meaning of "the last day of the
-        # month", no matter how many days there are in the month.
-        days << (i == 31 ? 'last' : i + 1)
-      end
-
-      bitfield = bitfield >> 1
-      i += 1
-    end
-
-    days
-  end
-
-  def days_of_week_from_bitfield(bitfield)
-    days_of_week = []
-
-    scheduler_days_of_week.each do |day_of_week|
-      if bitfield & day_of_week != 0
-        days_of_week << day_of_week_constant_to_name(day_of_week)
-      end
-    end
-
-    days_of_week
-  end
-
-  def scheduler_trigger_types
-    [
-      Win32::TaskScheduler::TASK_TIME_TRIGGER_DAILY,
-      Win32::TaskScheduler::TASK_TIME_TRIGGER_WEEKLY,
-      Win32::TaskScheduler::TASK_TIME_TRIGGER_MONTHLYDATE,
-      Win32::TaskScheduler::TASK_TIME_TRIGGER_MONTHLYDOW,
-      Win32::TaskScheduler::TASK_TIME_TRIGGER_ONCE
-    ]
-  end
-
-  def scheduler_days_of_week
-    [
-      Win32::TaskScheduler::SUNDAY,
-      Win32::TaskScheduler::MONDAY,
-      Win32::TaskScheduler::TUESDAY,
-      Win32::TaskScheduler::WEDNESDAY,
-      Win32::TaskScheduler::THURSDAY,
-      Win32::TaskScheduler::FRIDAY,
-      Win32::TaskScheduler::SATURDAY
-    ]
-  end
-
-  def scheduler_months
-    [
-      Win32::TaskScheduler::JANUARY,
-      Win32::TaskScheduler::FEBRUARY,
-      Win32::TaskScheduler::MARCH,
-      Win32::TaskScheduler::APRIL,
-      Win32::TaskScheduler::MAY,
-      Win32::TaskScheduler::JUNE,
-      Win32::TaskScheduler::JULY,
-      Win32::TaskScheduler::AUGUST,
-      Win32::TaskScheduler::SEPTEMBER,
-      Win32::TaskScheduler::OCTOBER,
-      Win32::TaskScheduler::NOVEMBER,
-      Win32::TaskScheduler::DECEMBER
-    ]
-  end
-
-  def scheduler_occurrences
-    [
-      Win32::TaskScheduler::FIRST_WEEK,
-      Win32::TaskScheduler::SECOND_WEEK,
-      Win32::TaskScheduler::THIRD_WEEK,
-      Win32::TaskScheduler::FOURTH_WEEK,
-      Win32::TaskScheduler::LAST_WEEK
-    ]
-  end
-
-  def day_of_week_constant_to_name(constant)
-    case constant
-    when Win32::TaskScheduler::SUNDAY;    'sun'
-    when Win32::TaskScheduler::MONDAY;    'mon'
-    when Win32::TaskScheduler::TUESDAY;   'tues'
-    when Win32::TaskScheduler::WEDNESDAY; 'wed'
-    when Win32::TaskScheduler::THURSDAY;  'thurs'
-    when Win32::TaskScheduler::FRIDAY;    'fri'
-    when Win32::TaskScheduler::SATURDAY;  'sat'
-    end
-  end
-
-  def day_of_week_name_to_constant(name)
-    case name
-    when 'sun';   Win32::TaskScheduler::SUNDAY
-    when 'mon';   Win32::TaskScheduler::MONDAY
-    when 'tues';  Win32::TaskScheduler::TUESDAY
-    when 'wed';   Win32::TaskScheduler::WEDNESDAY
-    when 'thurs'; Win32::TaskScheduler::THURSDAY
-    when 'fri';   Win32::TaskScheduler::FRIDAY
-    when 'sat';   Win32::TaskScheduler::SATURDAY
-    end
-  end
-
-  def month_constant_to_number(constant)
-    month_num = 1
-    while constant >> month_num - 1 > 1
-      month_num += 1
-    end
-    month_num
-  end
-
-  def occurrence_constant_to_name(constant)
-    case constant
-    when Win32::TaskScheduler::FIRST_WEEK;  'first'
-    when Win32::TaskScheduler::SECOND_WEEK; 'second'
-    when Win32::TaskScheduler::THIRD_WEEK;  'third'
-    when Win32::TaskScheduler::FOURTH_WEEK; 'fourth'
-    when Win32::TaskScheduler::LAST_WEEK;   'last'
-    end
-  end
-
-  def occurrence_name_to_constant(name)
-    case name
-    when 'first';  Win32::TaskScheduler::FIRST_WEEK
-    when 'second'; Win32::TaskScheduler::SECOND_WEEK
-    when 'third';  Win32::TaskScheduler::THIRD_WEEK
-    when 'fourth'; Win32::TaskScheduler::FOURTH_WEEK
-    when 'last';   Win32::TaskScheduler::LAST_WEEK
-    end
   end
 end

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -54,6 +54,21 @@ module TaskScheduler2
 
   RESERVED_FOR_FUTURE_USE = 0
 
+  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa381283(v=vs.85).aspx
+  TASK_FLAG_INTERACTIVE                  = 0x1
+  TASK_FLAG_DELETE_WHEN_DONE             = 0x2
+  TASK_FLAG_DISABLED                     = 0x4
+  TASK_FLAG_START_ONLY_IF_IDLE           = 0x10
+  TASK_FLAG_KILL_ON_IDLE_END             = 0x20
+  TASK_FLAG_DONT_START_IF_ON_BATTERIES   = 0x40
+  TASK_FLAG_KILL_IF_GOING_ON_BATTERIES   = 0x80
+  TASK_FLAG_RUN_ONLY_IF_DOCKED           = 0x100
+  TASK_FLAG_HIDDEN                       = 0x200
+  TASK_FLAG_RUN_IF_CONNECTED_TO_INTERNET = 0x400
+  TASK_FLAG_RESTART_ON_IDLE_RESUME       = 0x800
+  TASK_FLAG_SYSTEM_REQUIRED              = 0x1000
+  TASK_FLAG_RUN_ONLY_IF_LOGGED_ON        = 0x2000
+
   def self.folder_path_from_task_path(task_path)
     path = task_path.rpartition('\\')[0]
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_task.rb
@@ -212,14 +212,14 @@ class TaskScheduler2Task
   #
   def flags
     flags = 0
-    flags = flags | Win32::TaskScheduler::DISABLED if !@definition.Settings.Enabled
+    flags = flags | PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED if !@definition.Settings.Enabled
     flags
   end
 
   # Sets an OR'd value of flags that modify the behavior of the work item.
   #
   def flags=(flags)
-    @definition.Settings.Enabled = (flags & Win32::TaskScheduler::DISABLED == 0)
+    @definition.Settings.Enabled = (flags & PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED == 0)
   end
 
   # Returns whether or not the scheduled task exists.

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task.rb
@@ -217,14 +217,14 @@ class TaskScheduler2V1Task
   #
   def flags
     flags = 0
-    flags = flags | Win32::TaskScheduler::DISABLED if !@definition.Settings.Enabled
+    flags = flags | PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED if !@definition.Settings.Enabled
     flags
   end
 
   # Sets an OR'd value of flags that modify the behavior of the work item.
   #
   def flags=(flags)
-    @definition.Settings.Enabled = (flags & Win32::TaskScheduler::DISABLED == 0)
+    @definition.Settings.Enabled = (flags & PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED == 0)
   end
 
   # Returns whether or not the scheduled task exists.

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task_spec.rb
@@ -18,7 +18,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task", :if => Pupp
       task = Win32::TaskScheduler.new(@task_name, PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.default_trigger_for('once'))
       task.application_name = 'cmd.exe'
       task.parameters = '/c exit 0'
-      task.flags = Win32::TaskScheduler::DISABLED
+      task.flags = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED
       task.save
     end
 
@@ -50,7 +50,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task", :if => Pupp
       task = Win32::TaskScheduler.new(@task_name, PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.default_trigger_for('once'))
       task.application_name = 'cmd.exe'
       task.parameters = '/c exit 0'
-      task.flags = Win32::TaskScheduler::DISABLED
+      task.flags = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED
       task.save
     end
 

--- a/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -124,7 +124,7 @@ case task_provider
 when :win32_taskscheduler
   concrete_klass = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task
 when :taskscheduler_api2
-  concrete_klass = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task
+  concrete_klass = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2Task
 end
 
 describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Puppet.features.microsoft_windows? do

--- a/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -120,17 +120,18 @@ describe Puppet::Type.type(:scheduled_task).provider(:taskscheduler_api2), :if =
   end
 end
 
-# The Win32::TaskScheduler and PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task classes should be
-# API compatible and behave the same way.  What differs is which Windows API is used to query
-# and affect the system.  This means for testing, any tests should be the same no matter what
-# provider or concrete class (which the provider uses) is used.
-klass_list = Puppet.features.microsoft_windows? ? [Win32::TaskScheduler, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task] : []
-klass_list.each do |concrete_klass|
+# The win32_taskscheduler and taskscheduler_api2 providers should be API compatible and behave
+# the same way.  What differs is which Windows API is used to query and affect the system.
+# This means for testing, any tests should be the same no matter what provider or concrete class
+# (which the provider uses) is used.
+task_providers = Puppet.features.microsoft_windows? ? [:win32_taskscheduler, :taskscheduler_api2] : []
+task_providers.each do |task_provider|
 
-if concrete_klass == PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task
-  task_provider = :taskscheduler_api2
-else
-  task_provider = :win32_taskscheduler
+case task_provider
+when :win32_taskscheduler
+  concrete_klass = Win32::TaskScheduler
+when :taskscheduler_api2
+  concrete_klass = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task
 end
 
 describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Puppet.features.microsoft_windows? do

--- a/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -2,19 +2,12 @@
 require 'spec_helper'
 
 require 'puppet/util/windows/taskscheduler' if Puppet.features.microsoft_windows?
-require 'puppet_x/puppetlabs/scheduled_task/taskscheduler2_v1task' if Puppet.features.microsoft_windows?
+require 'puppet_x/puppetlabs/scheduled_task/taskscheduler2_task' if Puppet.features.microsoft_windows?
 
 shared_examples_for "a trigger that handles start_date and start_time" do
   let(:trigger) do
-    if described_class == Puppet::Type::Scheduled_task::ProviderWin32_taskscheduler
-      described_class.new(
-        :name => 'Shared Test Task',
-        :command => 'C:\Windows\System32\notepad.exe'
-      ).translate_hash_to_trigger(trigger_hash)
-    else
       PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.from_manifest_hash(trigger_hash)
     end
-  end
 
   before :each do
     Win32::TaskScheduler.any_instance.stubs(:save)
@@ -129,7 +122,7 @@ task_providers.each do |task_provider|
 
 case task_provider
 when :win32_taskscheduler
-  concrete_klass = Win32::TaskScheduler
+  concrete_klass = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task
 when :taskscheduler_api2
   concrete_klass = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2V1Task
 end
@@ -475,13 +468,7 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
           'start_minute' => 21,
           'flags'        => 0,
         })
-        if task_provider == :win32_taskscheduler
-          @mock_task.expects(:trigger).with(1).raises(
-            Win32::TaskScheduler::Error.new('Unknown trigger type')
-          )
-        else
           @mock_task.expects(:trigger).with(1).returns(nil)
-        end
 
         @mock_task.expects(:trigger).with(2).returns({
           'trigger_type' => :TASK_TIME_TRIGGER_ONCE,
@@ -526,9 +513,6 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
           'start_minute' => 21,
           'flags'        => 0,
         })
-        @trigger1 = task_provider == :win32_taskscheduler ?
-          { 'trigger_type' => Win32::TaskScheduler::TASK_EVENT_TRIGGER_AT_LOGON, } :
-          nil
         @mock_task.expects(:trigger).with(1).returns(@trigger1)
 
         @mock_task.expects(:trigger).with(2).returns({
@@ -1213,20 +1197,6 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
     end
   end
 
-  describe '#normalized_date',
-    :if => described_class == Puppet::Type::Scheduled_task::ProviderWin32_taskscheduler do
-    it 'should format the date without leading zeros' do
-      expect(described_class.normalized_date('2011-01-01')).to eq('2011-1-1')
-    end
-  end
-
-  describe '#normalized_time',
-    :if => described_class == Puppet::Type::Scheduled_task::ProviderWin32_taskscheduler do
-    it 'should format the time as {24h}:{minutes}' do
-      expect(described_class.normalized_time('8:37 PM')).to eq('20:37')
-    end
-  end
-
   describe '#from_manifest_hash' do
     before :each do
       @puppet_trigger = {
@@ -1236,12 +1206,8 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
     end
     let(:provider) { described_class.new(:name => 'Test Task', :command => 'C:\Windows\System32\notepad.exe') }
     let(:trigger) do
-      if provider.is_a?(Puppet::Type::Scheduled_task::ProviderWin32_taskscheduler)
-        provider.translate_hash_to_trigger(@puppet_trigger)
-      else
         PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.from_manifest_hash(@puppet_trigger)
       end
-    end
 
     context "working with repeat every x triggers" do
       before :each do
@@ -1801,15 +1767,8 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
           {'schedule' => 'once', 'start_date' => '2011-09-15', 'start_time' => '15:10', 'index' => 0},
         ]
         resource.provider.stubs(:trigger).returns(current_triggers)
-        if resource.provider.is_a?(Puppet::Type::Scheduled_task::ProviderWin32_taskscheduler)
-          translater = resource.provider.method(:translate_hash_to_trigger)
-          expected_method = :trigger=
-        else
-          translater = PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.method(:from_manifest_hash)
-          expected_method = :append_trigger
-        end
-        @mock_task.expects(expected_method).with(translater.call(@trigger[1]))
-        @mock_task.expects(expected_method).with(translater.call(@trigger[2]))
+        @mock_task.expects(:append_trigger).with(PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.from_manifest_hash(@trigger[1]))
+        @mock_task.expects(:append_trigger).with(PuppetX::PuppetLabs::ScheduledTask::Trigger::V1.from_manifest_hash(@trigger[2]))
 
         resource.provider.trigger = @trigger
       end


### PR DESCRIPTION
Prior to this commit the Win32 provider in this module was a near
mirror of the existing provider in core Puppet.  In order to more
easily maintain the new module, to debug it, and to onboard team
members to maintaining it, this commit copies over the code from
the new provider into the old one. As the new provider was made
to keep in parity with the old one and the tests already existed
to verify this, the change is determined to be low risk.

In a future commit the V2 provider will be updated to manage
scheduled tasks of all compatibility modes and will be the code
which gets all new features and improvements. The legacy provider
will be frozen at a point in the near future for all changes
except for security and critical bug fixes.

This commit also updates the test suite to verify the changes and
removes unneccessary logic from the tests which were needed when
the providers did not share helper code.

However, in this iteration, the tests only run over the legacy
provider and not the V2 provider, though they are using the same
helper at this time.  In a future commit, when the V2 provider is
updated to use the new V2 helper, the test suite will again run
for both.