### PR TITLE
(MODULES-6868) Remove unnecessary library include

### DIFF
--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -1,7 +1,4 @@
-require 'puppet/util'
-
 Puppet::Type.newtype(:scheduled_task) do
-  include Puppet::Util
 
   @doc = "Installs and manages Windows Scheduled Tasks.  All attributes
     except `name`, `command`, and `trigger` are optional; see the description

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -1,5 +1,3 @@
-require 'puppet/util/windows'
-
 # The TaskScheduler2 class encapsulates taskscheduler settings and behavior using the v2 API
 # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383600(v=vs.85).aspx
 

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/v1adapter_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/v1adapter_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 require 'puppet/util/windows/taskscheduler' if Puppet.features.microsoft_windows?
-require 'puppet_x/puppetlabs/scheduled_task/v1adapter' if Puppet.features.microsoft_windows?
+require 'puppet_x/puppetlabs/scheduled_task/v1adapter'
 
 # These integration tests confirm that the tasks created in a V1 scheduled task APi are visible
 # in the V2 API, and that changes in the V2 API will appear in the V1 API.


### PR DESCRIPTION
Prior to this commit the taskscheduler2 helper required the puppet
win32 code from core puppet; there are no longer any constants or
other calls reliant on this code so we remove it.