### PR TITLE
(MODULES-6526) Fix win32_taskscheduler compatibility

### DIFF
--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -25,7 +25,7 @@ class V1Adapter
       TaskScheduler2.task_definition(@task)
     @task_password = nil
 
-    compatibility = TaskScheduler2::TASK_COMPATIBILITY_V1
+    self.compatibility = TaskScheduler2::TASK_COMPATIBILITY_V1
     set_account_information('',nil)
   end
 

--- a/spec/acceptance/should_create_task_spec.rb
+++ b/spec/acceptance/should_create_task_spec.rb
@@ -4,11 +4,11 @@ host = find_only_one("default")
 
 describe "Should create a scheduled task", :node => host do
 
-  before(:all) do
+  before(:each) do
     @taskname = "pl#{rand(999999).to_i}"
   end
 
-  after(:all) do
+  after(:each) do
     on(host, "schtasks.exe /delete /tn #{@taskname} /f", :accept_all_exit_codes => true) do |r|
       # Empty means deletion was ok.  The 'The system cannot find the file specified' error occurs
       # if the task does not exist

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/v1adapter_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/v1adapter_spec.rb
@@ -118,6 +118,10 @@ describe "PuppetX::PuppetLabs::ScheduledTask::V1Adapter", :if => Puppet.features
       expect(subjectv2.exists?(@task_name)).to be true
     end
 
+    it 'should have a compatibility value of 1' do
+      expect(subjectv2.new(@task_name).compatibility).to eq(1)
+    end
+
     it 'should have same properties in the V2 API' do
       subjectv1.activate(@task_name)
       v2task = subjectv2.new(@task_name)
@@ -128,6 +132,42 @@ describe "PuppetX::PuppetLabs::ScheduledTask::V1Adapter", :if => Puppet.features
       expect(v2task.trigger_count).to eq(subjectv1.trigger_count)
       v1manifest_hash = to_manifest_hash(subjectv1.trigger(0))
       expect(v2task.trigger(0)).to eq(v1manifest_hash)
+    end
+  end
+
+  context "When created by a V2 API" do
+    before(:all) do
+      @task_name = 'puppet_task_' + SecureRandom.uuid.to_s
+
+      # create default task with 0 triggers
+      task = PuppetX::PuppetLabs::ScheduledTask::V1Adapter.new(@task_name)
+      task.application_name = 'cmd.exe'
+      task.parameters = '/c exit 0'
+      task.save
+    end
+
+    after(:all) do
+      PuppetX::PuppetLabs::ScheduledTask::V1Adapter.delete(@task_name) if PuppetX::PuppetLabs::ScheduledTask::V1Adapter.exists?(@task_name)
+    end
+
+    it 'should be visible by the V2 API' do
+      expect(subjectv2.exists?(@task_name)).to be true
+    end
+
+    it 'should have a compatibility value of 1' do
+      expect(subjectv2.new(@task_name).compatibility).to eq(1)
+    end
+
+    it 'should have same properties in the V2 API' do
+      subjectv1.activate(@task_name)
+      v2task = subjectv2.new(@task_name)
+
+      # flags in Win32::TaskScheduler cover all possible flag values
+      # flags in V1Adapter only cover enabled status
+      expect(v2task.parameters).to eq(subjectv1.parameters)
+      expect(v2task.application_name).to eq(subjectv1.application_name)
+      expect(v2task.trigger_count).to eq(subjectv1.trigger_count)
+      # on triggers to actually compare for this test
     end
   end
 
@@ -149,6 +189,10 @@ describe "PuppetX::PuppetLabs::ScheduledTask::V1Adapter", :if => Puppet.features
 
     it 'should be visible by the V2 API' do
       expect(subjectv2.exists?(@task_name)).to be true
+    end
+
+    it 'should have a compatibility value of 1' do
+      expect(subjectv2.new(@task_name).compatibility).to eq(1)
     end
 
     it 'should have same properties in the V1 API' do


### PR DESCRIPTION
Builds on #38 which should be merged first

- Commit 77d2d4b introduced the setting of compatibility on the
   win32_taskscheduler provider.

   However, since it set `compatibility =`, the actual setter method
   for the class instance was never properly called, which would
   result in improper compatibility level being set.

   This may vary by host, but on Windows 2008R2, this defaulted to
   creating new tasks with a compatibility level of 2, instead of the
   desired 1.

 - Running a simple manifest like the following, would result in
   Puppet creating a new task with the wrong compatiblity level. Since
   the provider filters on a compatibility level of 1 or lower,
   subsequent runs would never see the existing task, and would think
   it necessary to create the task. In addition to setting the wrong
   compat level, it completely broke idempotency.

```puppet
scheduled_task { 'doIt-v1':
  command => 'C:\\Windows\\System32\\notepad.exe',
  provider => 'win32_taskscheduler',
  trigger => [{schedule => 'daily', minutes_interval => '30', start_time => '15:20'}],
}
```

 - Add new tests that create tasks with the V1Adapter and verify that
   compat is set properly.

   Modify existing tests as well to verify compat set properly.