### PR TITLE
(maint) Simplify flag getter/setter in adapters

### DIFF
--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -179,15 +179,13 @@ class V1Adapter
   # must OR the return value to determine the flags yourself.
   #
   def flags
-    flags = 0
-    flags = flags | TaskScheduler2::TASK_FLAG_DISABLED if !@definition.Settings.Enabled
-    flags
+    @definition.Settings.Enabled ? 0 : TaskScheduler2::TASK_FLAG_DISABLED
   end
 
   # Sets an OR'd value of flags that modify the behavior of the work item.
   #
-  def flags=(flags)
-    @definition.Settings.Enabled = (flags & TaskScheduler2::TASK_FLAG_DISABLED == 0)
+  def flags=(value)
+    @definition.Settings.Enabled = (value & TaskScheduler2::TASK_FLAG_DISABLED == 0)
   end
 
   private

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -183,15 +183,13 @@ class V2Adapter
   # must OR the return value to determine the flags yourself.
   #
   def flags
-    flags = 0
-    flags = flags | TaskScheduler2::TASK_FLAG_DISABLED if !@definition.Settings.Enabled
-    flags
+    @definition.Settings.Enabled ? 0 : TaskScheduler2::TASK_FLAG_DISABLED
   end
 
   # Sets an OR'd value of flags that modify the behavior of the work item.
   #
-  def flags=(flags)
-    @definition.Settings.Enabled = (flags & TaskScheduler2::TASK_FLAG_DISABLED == 0)
+  def flags=(value)
+    @definition.Settings.Enabled = (value & TaskScheduler2::TASK_FLAG_DISABLED == 0)
   end
 
   private


### PR DESCRIPTION
 - There was confusing (especially with respect to scoping rules) code
   in adapters for getting / setting flag values.

   Remove the unneeded code in getter.

   Change variable names in setter to not be the same as the method