### PR TITLE
(maint) Reorganize / add all constants from taskschd.h

### DIFF
--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -75,6 +75,13 @@ module TaskScheduler2
     TASK_RUNLEVEL_HIGHEST = 1
   end
 
+  # https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/ne-taskschd-_task_processtokensid
+  class TASK_PROCESSTOKENSID_TYPE
+    TASK_PROCESSTOKENSID_NONE           = 0
+    TASK_PROCESSTOKENSID_UNRESTRICTED   = 1
+    TASK_PROCESSTOKENSID_DEFAULT        = 2
+  end
+
   RESERVED_FOR_FUTURE_USE = 0
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa381283(v=vs.85).aspx

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -82,6 +82,15 @@ module TaskScheduler2
     TASK_PROCESSTOKENSID_DEFAULT        = 2
   end
 
+  # https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/ne-taskschd-_task_state
+  class TASK_STATE
+    TASK_STATE_UNKNOWN    = 0
+    TASK_STATE_DISABLED   = 1
+    TASK_STATE_QUEUED     = 2
+    TASK_STATE_READY      = 3
+    TASK_STATE_RUNNING    = 4
+  end
+
   RESERVED_FOR_FUTURE_USE = 0
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa381283(v=vs.85).aspx

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -49,14 +49,16 @@ module TaskScheduler2
     TASK_IGNORE_REGISTRATION_TRIGGERS  = 0x20
   end
 
-  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383566(v=vs.85).aspx
-  TASK_LOGON_NONE                           = 0
-  TASK_LOGON_PASSWORD                       = 1
-  TASK_LOGON_S4U                            = 2
-  TASK_LOGON_INTERACTIVE_TOKEN              = 3
-  TASK_LOGON_GROUP                          = 4
-  TASK_LOGON_SERVICE_ACCOUNT                = 5
-  TASK_LOGON_INTERACTIVE_TOKEN_OR_PASSWORD  = 6
+  # https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/ne-taskschd-_task_logon_type
+  class TASK_LOGON_TYPE
+    TASK_LOGON_NONE                           = 0
+    TASK_LOGON_PASSWORD                       = 1
+    TASK_LOGON_S4U                            = 2
+    TASK_LOGON_INTERACTIVE_TOKEN              = 3
+    TASK_LOGON_GROUP                          = 4
+    TASK_LOGON_SERVICE_ACCOUNT                = 5
+    TASK_LOGON_INTERACTIVE_TOKEN_OR_PASSWORD  = 6
+  end
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa380747(v=vs.85).aspx
   TASK_RUNLEVEL_LUA     = 0
@@ -158,7 +160,7 @@ module TaskScheduler2
     task_password = nil
 
     case definition.Principal.LogonType
-      when TASK_LOGON_PASSWORD, TASK_LOGON_INTERACTIVE_TOKEN_OR_PASSWORD
+      when TASK_LOGON_TYPE::TASK_LOGON_PASSWORD, TASK_LOGON_TYPE::TASK_LOGON_INTERACTIVE_TOKEN_OR_PASSWORD
         task_user = definition.Principal.UserId
         task_password = password
     end
@@ -185,12 +187,12 @@ module TaskScheduler2
     if (user.nil? || user == "")
       # Setup for the local system account
       definition.Principal.UserId = 'SYSTEM'
-      definition.Principal.LogonType = TASK_LOGON_SERVICE_ACCOUNT
+      definition.Principal.LogonType = TASK_LOGON_TYPE::TASK_LOGON_SERVICE_ACCOUNT
       definition.Principal.RunLevel = TASK_RUNLEVEL_HIGHEST
       return true
     else
       definition.Principal.UserId = user
-      definition.Principal.LogonType = TASK_LOGON_PASSWORD
+      definition.Principal.LogonType = TASK_LOGON_TYPE::TASK_LOGON_PASSWORD
       definition.Principal.RunLevel = TASK_RUNLEVEL_HIGHEST
       return true
     end

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -13,11 +13,13 @@ module TaskScheduler2
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383558(v=vs.85).aspx
   TASK_ENUM_HIDDEN  = 0x1
 
-  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa380596(v=vs.85).aspx
-  TASK_ACTION_EXEC = 0
-  TASK_ACTION_COM_HANDLER = 5
-  TASK_ACTION_SEND_EMAIL = 6
-  TASK_ACTION_SHOW_MESSAGE = 7
+  # https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/ne-taskschd-_task_action_type
+  class TASK_ACTION_TYPE
+    TASK_ACTION_EXEC          = 0
+    TASK_ACTION_COM_HANDLER   = 5
+    TASK_ACTION_SEND_EMAIL    = 6
+    TASK_ACTION_SHOW_MESSAGE  = 7
+  end
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383557(v=vs.85).aspx
   # Undocumented values

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -69,9 +69,11 @@ module TaskScheduler2
     TASK_RUN_USER_SID             = 0x8
   end
 
-  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa380747(v=vs.85).aspx
-  TASK_RUNLEVEL_LUA     = 0
-  TASK_RUNLEVEL_HIGHEST = 1
+  # https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/ne-taskschd-_task_runlevel
+  class TASK_RUNLEVEL_TYPE
+    TASK_RUNLEVEL_LUA     = 0
+    TASK_RUNLEVEL_HIGHEST = 1
+  end
 
   RESERVED_FOR_FUTURE_USE = 0
 
@@ -197,12 +199,12 @@ module TaskScheduler2
       # Setup for the local system account
       definition.Principal.UserId = 'SYSTEM'
       definition.Principal.LogonType = TASK_LOGON_TYPE::TASK_LOGON_SERVICE_ACCOUNT
-      definition.Principal.RunLevel = TASK_RUNLEVEL_HIGHEST
+      definition.Principal.RunLevel = TASK_RUNLEVEL_TYPE::TASK_RUNLEVEL_HIGHEST
       return true
     else
       definition.Principal.UserId = user
       definition.Principal.LogonType = TASK_LOGON_TYPE::TASK_LOGON_PASSWORD
-      definition.Principal.RunLevel = TASK_RUNLEVEL_HIGHEST
+      definition.Principal.RunLevel = TASK_RUNLEVEL_TYPE::TASK_RUNLEVEL_HIGHEST
       return true
     end
   end

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -102,19 +102,9 @@ module TaskScheduler2
   RESERVED_FOR_FUTURE_USE = 0
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa381283(v=vs.85).aspx
-  TASK_FLAG_INTERACTIVE                  = 0x1
-  TASK_FLAG_DELETE_WHEN_DONE             = 0x2
+  # NOTE: this is a V1 API constant that shouldn't be in use
   TASK_FLAG_DISABLED                     = 0x4
-  TASK_FLAG_START_ONLY_IF_IDLE           = 0x10
-  TASK_FLAG_KILL_ON_IDLE_END             = 0x20
-  TASK_FLAG_DONT_START_IF_ON_BATTERIES   = 0x40
-  TASK_FLAG_KILL_IF_GOING_ON_BATTERIES   = 0x80
-  TASK_FLAG_RUN_ONLY_IF_DOCKED           = 0x100
-  TASK_FLAG_HIDDEN                       = 0x200
-  TASK_FLAG_RUN_IF_CONNECTED_TO_INTERNET = 0x400
-  TASK_FLAG_RESTART_ON_IDLE_RESUME       = 0x800
-  TASK_FLAG_SYSTEM_REQUIRED              = 0x1000
-  TASK_FLAG_RUN_ONLY_IF_LOGGED_ON        = 0x2000
+  # TASK_FLAG_RUN_ONLY_IF_LOGGED_ON        = 0x2000
 
   def self.folder_path_from_task_path(task_path)
     path = task_path.rpartition('\\')[0]

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -60,6 +60,15 @@ module TaskScheduler2
     TASK_LOGON_INTERACTIVE_TOKEN_OR_PASSWORD  = 6
   end
 
+  # https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/ne-taskschd-_task_run_flags
+  class TASK_RUN_FLAGS
+    TASK_RUN_NO_FLAGS             = 0
+    TASK_RUN_AS_SELF              = 0x1
+    TASK_RUN_IGNORE_CONSTRAINTS   = 0x2
+    TASK_RUN_USE_SESSION_ID       = 0x4
+    TASK_RUN_USER_SID             = 0x8
+  end
+
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa380747(v=vs.85).aspx
   TASK_RUNLEVEL_LUA     = 0
   TASK_RUNLEVEL_HIGHEST = 1

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -91,6 +91,14 @@ module TaskScheduler2
     TASK_STATE_RUNNING    = 4
   end
 
+  # https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/ne-taskschd-_task_instances_policy
+  class TASK_INSTANCES_POLICY
+    TASK_INSTANCES_PARALLEL       = 0
+    TASK_INSTANCES_QUEUE          = 1
+    TASK_INSTANCES_IGNORE_NEW     = 2
+    TASK_INSTANCES_STOP_EXISTING  = 3
+  end
+
   RESERVED_FOR_FUTURE_USE = 0
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa381283(v=vs.85).aspx

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -37,14 +37,17 @@ module TaskScheduler2
     TASK_COMPATIBILITY_V2_4   = 6
   end
 
-  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382538%28v=vs.85%29.aspx
-  TASK_VALIDATE_ONLY                 = 0x1
-  TASK_CREATE                        = 0x2
-  TASK_UPDATE                        = 0x4
-  TASK_CREATE_OR_UPDATE              = 0x6
-  TASK_DISABLE                       = 0x8
-  TASK_DONT_ADD_PRINCIPAL_ACE        = 0x10
-  TASK_IGNORE_REGISTRATION_TRIGGERS  = 0x20
+  # https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/ne-taskschd-_task_creation
+  class TASK_CREATION
+    TASK_VALIDATE_ONLY                 = 0x1
+    TASK_CREATE                        = 0x2
+    TASK_UPDATE                        = 0x4
+    # ( TASK_CREATE | TASK_UPDATE )
+    TASK_CREATE_OR_UPDATE              = 0x6
+    TASK_DISABLE                       = 0x8
+    TASK_DONT_ADD_PRINCIPAL_ACE        = 0x10
+    TASK_IGNORE_REGISTRATION_TRIGGERS  = 0x20
+  end
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383566(v=vs.85).aspx
   TASK_LOGON_NONE                           = 0
@@ -160,7 +163,7 @@ module TaskScheduler2
         task_password = password
     end
     task_folder.RegisterTaskDefinition(task_name_from_task_path(task_path),
-                                       definition, TASK_CREATE_OR_UPDATE, task_user, task_password,
+                                       definition, TASK_CREATION::TASK_CREATE_OR_UPDATE, task_user, task_password,
                                        definition.Principal.LogonType)
   end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -23,18 +23,19 @@ module TaskScheduler2
     TASK_ACTION_SHOW_MESSAGE  = 7
   end
 
-  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383557(v=vs.85).aspx
-  # Undocumented values
+  # https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/ne-taskschd-_task_compatibility
   # Win7/2008 R2                       = 3
   # Win8/Server 2012 R2 or Server 2016 = 4
   # Windows 10                         = 5 / 6
-  TASK_COMPATIBILITY_AT = 0
-  TASK_COMPATIBILITY_V1 = 1
-  TASK_COMPATIBILITY_V2 = 2
-  TASK_COMPATIBILITY_V2_1 = 3
-  TASK_COMPATIBILITY_V2_2 = 4
-  TASK_COMPATIBILITY_V2_3 = 5
-  TASK_COMPATIBILITY_V2_4 = 6
+  class TASK_COMPATIBILITY
+    TASK_COMPATIBILITY_AT     = 0
+    TASK_COMPATIBILITY_V1     = 1
+    TASK_COMPATIBILITY_V2     = 2
+    TASK_COMPATIBILITY_V2_1   = 3
+    TASK_COMPATIBILITY_V2_2   = 4
+    TASK_COMPATIBILITY_V2_3   = 5
+    TASK_COMPATIBILITY_V2_4   = 6
+  end
 
   # https://msdn.microsoft.com/en-us/library/windows/desktop/aa382538%28v=vs.85%29.aspx
   TASK_VALIDATE_ONLY                 = 0x1

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -10,8 +10,10 @@ module TaskScheduler2
   # The name of the root folder for tasks
   ROOT_FOLDER = '\\'.freeze
 
-  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383558(v=vs.85).aspx
-  TASK_ENUM_HIDDEN  = 0x1
+  # https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/ne-taskschd-_task_enum_flags
+  class TASK_ENUM_FLAGS
+    TASK_ENUM_HIDDEN  = 0x1
+  end
 
   # https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/ne-taskschd-_task_action_type
   class TASK_ACTION_TYPE
@@ -101,7 +103,7 @@ module TaskScheduler2
 
     task_folder = task_service.GetFolder(folder_path)
     filter_compatibility = !options[:include_compatibility].empty?
-    task_folder.GetTasks(TASK_ENUM_HIDDEN).each do |task|
+    task_folder.GetTasks(TASK_ENUM_FLAGS::TASK_ENUM_HIDDEN).each do |task|
       next if filter_compatibility && !options[:include_compatibility].include?(task.Definition.Settings.Compatibility)
       array << task.Path
     end

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -491,6 +491,16 @@ module Trigger
       TASK_TRIGGER_CUSTOM_TRIGGER_01     = 12
     end
 
+    # https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/ne-taskschd-_task_session_state_change_type
+    class SessionStateChangeType
+      TASK_CONSOLE_CONNECT      = 1
+      TASK_CONSOLE_DISCONNECT   = 2
+      TASK_REMOTE_CONNECT       = 3
+      TASK_REMOTE_DISCONNECT    = 4
+      TASK_SESSION_LOCK         = 7
+      TASK_SESSION_UNLOCK       = 8
+    end
+
     SCHEDULE_BASED_TRIGGER_MAP = {
       Type::TASK_TRIGGER_DAILY      => 'daily',
       Type::TASK_TRIGGER_WEEKLY     => 'weekly',

--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -476,7 +476,7 @@ module Trigger
 
   class V2
     class Type
-      # https://msdn.microsoft.com/en-us/library/windows/desktop/aa383915%28v=vs.85%29.aspx
+      # https://docs.microsoft.com/en-us/windows/desktop/api/taskschd/ne-taskschd-_task_trigger_type2
       TASK_TRIGGER_EVENT                 = 0
       TASK_TRIGGER_TIME                  = 1
       TASK_TRIGGER_DAILY                 = 2
@@ -488,6 +488,7 @@ module Trigger
       TASK_TRIGGER_BOOT                  = 8
       TASK_TRIGGER_LOGON                 = 9
       TASK_TRIGGER_SESSION_STATE_CHANGE  = 11
+      TASK_TRIGGER_CUSTOM_TRIGGER_01     = 12
     end
 
     SCHEDULE_BASED_TRIGGER_MAP = {

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -196,12 +196,12 @@ class V1Adapter
     action = nil
     (1..TaskScheduler2.action_count(@definition)).each do |i|
       index_action = TaskScheduler2.action(@definition, i)
-      action = index_action if index_action.Type == TaskScheduler2::TASK_ACTION_EXEC
+      action = index_action if index_action.Type == TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC
       break if action
     end
 
     if action.nil? && create_if_missing
-      action = TaskScheduler2.create_action(@definition, TaskScheduler2::TASK_ACTION_EXEC)
+      action = TaskScheduler2.create_action(@definition, TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC)
     end
 
     action

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -25,7 +25,7 @@ class V1Adapter
       TaskScheduler2.task_definition(@task)
     @task_password = nil
 
-    self.compatibility = TaskScheduler2::TASK_COMPATIBILITY_V1
+    self.compatibility = TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V1
     set_account_information('',nil)
   end
 
@@ -34,7 +34,10 @@ class V1Adapter
   def self.tasks
     TaskScheduler2.enum_task_names(TaskScheduler2::ROOT_FOLDER,
       include_child_folders: false,
-      include_compatibility: [TaskScheduler2::TASK_COMPATIBILITY_AT, TaskScheduler2::TASK_COMPATIBILITY_V1]).map do |item|
+      include_compatibility: [
+        TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_AT,
+        TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V1
+      ]).map do |item|
         TaskScheduler2.task_name_from_task_path(item)
     end
   end

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -200,12 +200,12 @@ class V2Adapter
     action = nil
     (1..TaskScheduler2.action_count(@definition)).each do |i|
       index_action = TaskScheduler2.action(@definition, i)
-      action = index_action if index_action.Type == TaskScheduler2::TASK_ACTION_EXEC
+      action = index_action if index_action.Type == TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC
       break if action
     end
 
     if action.nil? && create_if_missing
-      action = TaskScheduler2.create_action(@definition, TaskScheduler2::TASK_ACTION_EXEC)
+      action = TaskScheduler2.create_action(@definition, TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC)
     end
 
     action

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -31,13 +31,13 @@ class V2Adapter
     TaskScheduler2.enum_task_names(TaskScheduler2::ROOT_FOLDER,
       include_child_folders: false,
       include_compatibility: [
-        TaskScheduler2::TASK_COMPATIBILITY_V2_4,
-        TaskScheduler2::TASK_COMPATIBILITY_V2_3,
-        TaskScheduler2::TASK_COMPATIBILITY_V2_2,
-        TaskScheduler2::TASK_COMPATIBILITY_V2_1,
-        TaskScheduler2::TASK_COMPATIBILITY_V2,
-        TaskScheduler2::TASK_COMPATIBILITY_AT,
-        TaskScheduler2::TASK_COMPATIBILITY_V1
+        TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V2_4,
+        TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V2_3,
+        TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V2_2,
+        TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V2_1,
+        TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V2,
+        TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_AT,
+        TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V1
       ]).map do |item|
         TaskScheduler2.task_name_from_task_path(item)
     end

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
@@ -38,7 +38,7 @@ def create_test_task(task_name = nil, task_compatiblity = ST::TaskScheduler2::TA
   trigger = definition.Triggers.Create(ST::Trigger::V2::Type::TASK_TRIGGER_TIME)
   trigger.StartBoundary = '2017-09-11T14:02:00'
   # Create an action
-  new_action = tasksched.create_action(definition, tasksched::TASK_ACTION_EXEC)
+  new_action = tasksched.create_action(definition, tasksched::TASK_ACTION_TYPE::TASK_ACTION_EXEC)
   new_action.Path = 'cmd.exe'
   new_action.Arguments = '/c exit 0'
   tasksched.save(task_name, definition)
@@ -144,7 +144,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2", :if => Puppet.fea
       end
 
       it 'should have an action of type Execution' do
-        expect(subject.action(task_definition, 1).Type).to eq(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_ACTION_EXEC)
+        expect(subject.action(task_definition, 1).Type).to eq(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC)
       end
 
       it 'should have the specified action path' do

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
@@ -26,7 +26,7 @@ end
 
 ST = PuppetX::PuppetLabs::ScheduledTask
 
-def create_test_task(task_name = nil, task_compatiblity = ST::TaskScheduler2::TASK_COMPATIBILITY_V2)
+def create_test_task(task_name = nil, task_compatiblity = ST::TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V2)
   tasksched = ST::TaskScheduler2
   task_name = tasksched::ROOT_FOLDER + 'puppet_task_' + SecureRandom.uuid.to_s if task_name.nil?
   definition = tasksched.new_task_definition
@@ -53,7 +53,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2", :if => Puppet.fea
   describe '#enum_task_names' do
     before(:all) do
       # Need a V1 task as a test fixture
-      @task_name = create_test_task(nil, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_V1)
+      @task_name = create_test_task(nil, PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V1)
     end
 
     after(:all) do
@@ -73,7 +73,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2", :if => Puppet.fea
     end
 
     it 'should only return compatible tasks if specified' do
-      subject_count = subject.enum_task_names(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::ROOT_FOLDER, { :include_compatibility => [PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_V1]}).count
+      subject_count = subject.enum_task_names(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::ROOT_FOLDER, { :include_compatibility => [PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V1]}).count
       ps_cmd = '(Get-ScheduledTask | ? { [Int]$_.Settings.Compatibility -eq 1 } | Measure-Object).count'
       expect(subject_count).to be_same_as_powershell_command(ps_cmd)
     end
@@ -128,7 +128,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2", :if => Puppet.fea
       end
 
       it 'should be V2 compatible' do
-        expect(subject.compatibility(task_definition)).to eq(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY_V2)
+        expect(subject.compatibility(task_definition)).to eq(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V2)
       end
 
       it 'should have a single trigger' do


### PR DESCRIPTION
Instead of having all constants remain under the `TaskScheduler2` namespace, prefix each set of constants with their appropriate type. Also:

* Adds missing constants
* Adds missing types of constants
* Updates MSDN links to point to newer docs
* Removes the mostly unused V1 flag constants