### PR TITLE
(MODULES-7420) Remove flags

### DIFF
--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
   end
 
   def enabled
-    task.flags & PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED == 0 ? :true : :false
+    task.enabled ? :true : :false
   end
 
   def command
@@ -106,11 +106,7 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
   end
 
   def enabled=(value)
-    if value == :true
-      task.flags = task.flags & ~PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED
-    else
-      task.flags = task.flags | PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED
-    end
+    task.enabled = (value == :true)
   end
 
   def compatibility=(value)

--- a/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
+++ b/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
   end
 
   def enabled
-    task.flags & PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED == 0 ? :true : :false
+    task.enabled ? :true : :false
   end
 
   def command
@@ -99,11 +99,7 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
   end
 
   def enabled=(value)
-    if value == :true
-      task.flags = task.flags & ~PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED
-    else
-      task.flags = task.flags | PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED
-    end
+    task.enabled = (value == :true)
   end
 
   def trigger=(value)

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -103,11 +103,6 @@ module TaskScheduler2
 
   RESERVED_FOR_FUTURE_USE = 0
 
-  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa381283(v=vs.85).aspx
-  # NOTE: this is a V1 API constant that shouldn't be in use
-  TASK_FLAG_DISABLED                     = 0x4
-  # TASK_FLAG_RUN_ONLY_IF_LOGGED_ON        = 0x2000
-
   def self.is_com_error_type(win32OLERuntimeError, hresult)
     # to_s(16) does not include 0x prefix
     # assume actual hex for error is what message contains - i.e. 80070002

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -71,10 +71,6 @@ class V1Adapter
   #
   # Note that if intending to use SYSTEM, specify an empty user and nil password
   #
-  # Calling task.set_account_information('SYSTEM', nil) will generally not
-  # work, except for one special case where flags are also set like:
-  # task.flags = TaskScheduler2::TASK_FLAG_RUN_ONLY_IF_LOGGED_ON
-  #
   # This must be done prior to the 1st save() call for the task to be
   # properly registered and visible through the MMC snap-in / schtasks.exe
   #
@@ -178,17 +174,12 @@ class V1Adapter
     Trigger::V2.append_trigger(@definition, manifest_hash)
   end
 
-  # Returns the flags (integer) that modify the behavior of the work item. You
-  # must OR the return value to determine the flags yourself.
-  #
-  def flags
-    @definition.Settings.Enabled ? 0 : TaskScheduler2::TASK_FLAG_DISABLED
+  def enabled
+    @definition.Settings.Enabled
   end
 
-  # Sets an OR'd value of flags that modify the behavior of the work item.
-  #
-  def flags=(value)
-    @definition.Settings.Enabled = (value & TaskScheduler2::TASK_FLAG_DISABLED == 0)
+  def enabled=(value)
+    @definition.Settings.Enabled = value
   end
 
   private

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -72,10 +72,6 @@ class V2Adapter
   #
   # Note that if intending to use SYSTEM, specify an empty user and nil password
   #
-  # Calling task.set_account_information('SYSTEM', nil) will generally not
-  # work, except for one special case where flags are also set like:
-  # task.flags = TaskScheduler2::TASK_FLAG_RUN_ONLY_IF_LOGGED_ON
-  #
   # This must be done prior to the 1st save() call for the task to be
   # properly registered and visible through the MMC snap-in / schtasks.exe
   #
@@ -179,17 +175,12 @@ class V2Adapter
     Trigger::V2.append_trigger(@definition, manifest_hash)
   end
 
-  # Returns the flags (integer) that modify the behavior of the work item. You
-  # must OR the return value to determine the flags yourself.
-  #
-  def flags
-    @definition.Settings.Enabled ? 0 : TaskScheduler2::TASK_FLAG_DISABLED
+  def enabled
+    @definition.Settings.Enabled
   end
 
-  # Sets an OR'd value of flags that modify the behavior of the work item.
-  #
-  def flags=(value)
-    @definition.Settings.Enabled = (value & TaskScheduler2::TASK_FLAG_DISABLED == 0)
+  def enabled=(value)
+    @definition.Settings.Enabled = value
   end
 
   private

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/v1adapter_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/v1adapter_spec.rb
@@ -126,7 +126,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::V1Adapter", :if => Puppet.features
       task = Win32::TaskScheduler.new(@task_name, default_once_trigger)
       task.application_name = 'cmd.exe'
       task.parameters = '/c exit 0'
-      task.flags = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED
+      task.flags = Win32::TaskScheduler::TASK_FLAG_DISABLED
       task.save
     end
 
@@ -147,7 +147,10 @@ describe "PuppetX::PuppetLabs::ScheduledTask::V1Adapter", :if => Puppet.features
       subjectv1.activate(@task_name)
       v2task = subjectv2.new(@task_name)
 
-      expect(v2task.flags).to eq(subjectv1.flags)
+      # flags in Win32::TaskScheduler cover all possible flag values
+      # flags in V1Adapter only cover enabled status
+      v1_disabled = (subjectv1.flags & Win32::TaskScheduler::TASK_FLAG_DISABLED) == Win32::TaskScheduler::TASK_FLAG_DISABLED
+      expect(v2task.enabled).to eq(!v1_disabled)
       expect(v2task.parameters).to eq(subjectv1.parameters)
       expect(v2task.application_name).to eq(subjectv1.application_name)
       expect(v2task.trigger_count).to eq(subjectv1.trigger_count)
@@ -185,6 +188,8 @@ describe "PuppetX::PuppetLabs::ScheduledTask::V1Adapter", :if => Puppet.features
 
       # flags in Win32::TaskScheduler cover all possible flag values
       # flags in V1Adapter only cover enabled status
+      v1_disabled = (subjectv1.flags & Win32::TaskScheduler::TASK_FLAG_DISABLED) == Win32::TaskScheduler::TASK_FLAG_DISABLED
+      expect(v2task.enabled).to eq(!v1_disabled)
       expect(v2task.parameters).to eq(subjectv1.parameters)
       expect(v2task.application_name).to eq(subjectv1.application_name)
       expect(v2task.trigger_count).to eq(subjectv1.trigger_count)
@@ -199,7 +204,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::V1Adapter", :if => Puppet.features
       task = Win32::TaskScheduler.new(@task_name, default_once_trigger)
       task.application_name = 'cmd.exe'
       task.parameters = '/c exit 0'
-      task.flags = PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED
+      task.flags = Win32::TaskScheduler::TASK_FLAG_DISABLED
       task.save
     end
 
@@ -224,7 +229,10 @@ describe "PuppetX::PuppetLabs::ScheduledTask::V1Adapter", :if => Puppet.features
 
       subjectv1.activate(@task_name)
 
-      expect(subjectv1.flags).to eq(v2task.flags)
+      # flags in Win32::TaskScheduler cover all possible flag values
+      # flags in V1Adapter only cover enabled status
+      v1_disabled = (subjectv1.flags & Win32::TaskScheduler::TASK_FLAG_DISABLED) == Win32::TaskScheduler::TASK_FLAG_DISABLED
+      expect(!v1_disabled).to eq(v2task.enabled)
       expect(subjectv1.parameters).to eq(arguments_after)
       expect(subjectv1.application_name).to eq(v2task.application_name)
       expect(subjectv1.trigger_count).to eq(v2task.trigger_count)

--- a/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
+++ b/spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb
@@ -424,19 +424,19 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
 
     describe 'whether the task is enabled' do
       it 'should report tasks with the disabled bit set as disabled' do
-        @mock_task.stubs(:flags).returns(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED)
+        @mock_task.stubs(:enabled).returns(false)
 
         expect(resource.provider.enabled).to eq(:false)
       end
 
       it 'should report tasks without the disabled bit set as enabled' do
-        @mock_task.stubs(:flags).returns(~PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED)
+        @mock_task.stubs(:enabled).returns(true)
 
         expect(resource.provider.enabled).to eq(:true)
       end
 
       it 'should not consider triggers for determining if the task is enabled' do
-        @mock_task.stubs(:flags).returns(~PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED)
+        @mock_task.stubs(:enabled).returns(:true)
         @mock_task.stubs(:trigger_count).returns(1)
         manifest = PuppetX::PuppetLabs::ScheduledTask::Trigger::Manifest
         default_once = manifest.default_trigger_for('once').merge(
@@ -1090,16 +1090,16 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
     end
 
     describe '#enabled=' do
-      it 'should set the disabled flag if the task should be disabled' do
-        @mock_task.stubs(:flags).returns(0)
-        @mock_task.expects(:flags=).with(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED)
+      it 'should set the enabled property if the task should be disabled' do
+        @mock_task.stubs(:enabled).returns(true)
+        @mock_task.expects(:enabled=).with(false)
 
         resource.provider.enabled = :false
       end
 
-      it 'should clear the disabled flag if the task should be enabled' do
-        @mock_task.stubs(:flags).returns(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_FLAG_DISABLED)
-        @mock_task.expects(:flags=).with(0)
+      it 'should clear the enabled property if the task should be enabled' do
+        @mock_task.stubs(:enabled).returns(false)
+        @mock_task.expects(:enabled=).with(true)
 
         resource.provider.enabled = :true
       end
@@ -1238,8 +1238,8 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
       @mock_task.stubs(:parameters=)
       @mock_task.stubs(:working_directory=)
       @mock_task.stubs(:set_account_information)
-      @mock_task.stubs(:flags)
-      @mock_task.stubs(:flags=)
+      @mock_task.stubs(:enabled)
+      @mock_task.stubs(:enabled=)
       @mock_task.stubs(:trigger_count).returns(0)
       @mock_task.stubs(:append_trigger)
       if resource.provider.is_a?(Puppet::Type::Scheduled_task::ProviderTaskscheduler_api2)
@@ -1302,8 +1302,8 @@ describe Puppet::Type.type(:scheduled_task).provider(task_provider), :if => Pupp
         @new_mock_task.stubs(:application_name=)
         @new_mock_task.stubs(:parameters=)
         @new_mock_task.stubs(:working_directory=)
-        @new_mock_task.stubs(:flags)
-        @new_mock_task.stubs(:flags=)
+        @new_mock_task.stubs(:enabled)
+        @new_mock_task.stubs(:enabled=)
         @new_mock_task.stubs(:delete_trigger)
         @new_mock_task.stubs(:append_trigger)
         @new_mock_task.stubs(:set_account_information)


### PR DESCRIPTION
 - Flags inside of scheduled tasks are a V1 construct. Without any V1
   API usage inside this module, this is replaced with an
   implementation that covers the only setting currently
   implemented - "Enabled".

 - Enabled flag is provided directly from the ITaskDefinition
   property Setting, which is an ITaskSettings interface pointer.

 - Flags only sticks around when testing against the old version of
   the code that was previously shipped in Puppet and implemented
   inside of Win32::TaskScheduler.