### PR TITLE
(MODULES-7425) Remove unnecessary TaskScheduler2 methods

### DIFF
--- a/lib/puppet_x/puppetlabs/scheduled_task/error.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/error.rb
@@ -11,6 +11,14 @@ module TaskScheduler2
       -(-hresult & MAX_32_BIT_VALUE)
     end
 
+    def self.is_com_error_type(win32OLERuntimeError, hresult)
+      # to_s(16) does not include 0x prefix
+      # assume actual hex for error is what message contains - i.e. 80070002
+      return true if win32OLERuntimeError.message =~ /#{hresult.to_s(16)}/
+      # if not, look for 2s complement (negative value) - i.e. -2147024894
+      win32OLERuntimeError.message =~ /#{to_signed_value(hresult)}/m
+    end
+
     # #define FACILITY_WIN32                   7
     # #define __HRESULT_FROM_WIN32(x) ((HRESULT)(x) <= 0 ? ((HRESULT)(x)) : ((HRESULT) (((x) & 0x0000FFFF) | (FACILITY_WIN32 << 16) | 0x80000000)))
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -103,14 +103,6 @@ module TaskScheduler2
 
   RESERVED_FOR_FUTURE_USE = 0
 
-  def self.is_com_error_type(win32OLERuntimeError, hresult)
-    # to_s(16) does not include 0x prefix
-    # assume actual hex for error is what message contains - i.e. 80070002
-    return true if win32OLERuntimeError.message =~ /#{hresult.to_s(16)}/
-    # if not, look for 2s complement (negative value) - i.e. -2147024894
-    win32OLERuntimeError.message =~ /#{Error.to_signed_value(hresult)}/m
-  end
-
   def self.task_name_from_task_path(task_path)
     task_path.rpartition('\\')[2]
   end
@@ -155,7 +147,7 @@ module TaskScheduler2
       _task = task_folder.GetTask(task_name_from_task_path(task_path))
       return _task, task_definition(_task)
     rescue WIN32OLERuntimeError => e
-      unless is_com_error_type(e, Error::ERROR_FILE_NOT_FOUND)
+      unless Error.is_com_error_type(e, Error::ERROR_FILE_NOT_FOUND)
         raise Puppet::Error.new( _("GetTask failed with: %{error}") % { error: e }, e )
       end
     end

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -223,22 +223,6 @@ module TaskScheduler2
     end
   end
 
-  # Task Actions
-  # Returns the number of actions associated with the active task.
-  #
-  def self.action(definition, index)
-    result = nil
-
-    begin
-      result = definition.Actions.Item(index)
-    rescue WIN32OLERuntimeError => err
-      raise unless is_com_error_type(err, Error::E_INVALIDARG)
-      result = nil
-    end
-
-    result
-  end
-
   # Task Triggers
   def self.trigger_count(definition)
     definition.Triggers.count

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -243,14 +243,6 @@ module TaskScheduler2
     result
   end
 
-  # Deletes the trigger at the specified index.
-  #
-  def self.delete_trigger(definition, index)
-    definition.Triggers.Remove(index)
-
-    index
-  end
-
   # Private methods
   def self.task_service
     service = WIN32OLE.new('Schedule.Service')

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -208,10 +208,6 @@ module TaskScheduler2
   end
 
   # General Properties
-  def self.principal(definition)
-    definition.Principal
-  end
-
   def self.set_principal(definition, user)
     if (user.nil? || user == "")
       # Setup for the local system account

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -223,11 +223,6 @@ module TaskScheduler2
     end
   end
 
-  # Task Triggers
-  def self.trigger_count(definition)
-    definition.Triggers.count
-  end
-
   # Returns a Win32OLE Trigger Object for the trigger at the given index for the
   # supplied definition.
   #

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -111,12 +111,6 @@ module TaskScheduler2
     win32OLERuntimeError.message =~ /#{Error.to_signed_value(hresult)}/m
   end
 
-  def self.folder_path_from_task_path(task_path)
-    path = task_path.rpartition('\\')[0]
-
-    path.empty? ? ROOT_FOLDER : path
-  end
-
   def self.task_name_from_task_path(task_path)
     task_path.rpartition('\\')[2]
   end
@@ -230,6 +224,13 @@ module TaskScheduler2
     definition
   end
   private_class_method :task_definition
+
+  def self.folder_path_from_task_path(task_path)
+    path = task_path.rpartition('\\')[0]
+
+    path.empty? ? ROOT_FOLDER : path
+  end
+  private_class_method :folder_path_from_task_path
 end
 
 end

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -223,26 +223,6 @@ module TaskScheduler2
     end
   end
 
-  # Returns a Win32OLE Trigger Object for the trigger at the given index for the
-  # supplied definition.
-  #
-  # Returns nil if the index does not exist
-  #
-  # Note - This is a 1 based array (not zero)
-  #
-  def self.trigger(definition, index)
-    result = nil
-
-    begin
-      result = definition.Triggers.Item(index)
-    rescue WIN32OLERuntimeError => err
-      raise unless is_com_error_type(err, Error::E_INVALIDARG)
-      result = nil
-    end
-
-    result
-  end
-
   # Private methods
   def self.task_service
     service = WIN32OLE.new('Schedule.Service')

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -223,19 +223,6 @@ module TaskScheduler2
     end
   end
 
-  # Returns the compatibility level of the task.
-  #
-  def self.compatibility(definition)
-    definition.Settings.Compatibility
-  end
-
-  # Sets the compatibility with the task.
-  # https://msdn.microsoft.com/en-us/library/windows/desktop/aa381846(v=vs.85).aspx
-  #
-  def self.set_compatibility(definition, value)
-    definition.Settings.Compatibility = value
-  end
-
   # Task Actions
   # Returns the number of actions associated with the active task.
   #

--- a/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/taskscheduler2.rb
@@ -226,10 +226,6 @@ module TaskScheduler2
   # Task Actions
   # Returns the number of actions associated with the active task.
   #
-  def self.action_count(definition)
-    definition.Actions.count
-  end
-
   def self.action(definition, index)
     result = nil
 
@@ -241,10 +237,6 @@ module TaskScheduler2
     end
 
     result
-  end
-
-  def self.create_action(definition, action_type)
-    definition.Actions.Create(action_type)
   end
 
   # Task Triggers

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -166,7 +166,7 @@ class V1Adapter
   def trigger(index)
     # The older V1 API uses a starting index of zero, wherease the V2 API uses one.
     # Need to increment by one to maintain the same behavior
-    trigger_object = TaskScheduler2.trigger(@definition, index + 1)
+    trigger_object = trigger_at(index + 1)
     trigger_object.nil? || Trigger::V2::TYPE_MANIFEST_MAP[trigger_object.Type].nil? ?
       nil :
       Trigger::V2.to_manifest_hash(trigger_object)
@@ -210,6 +210,26 @@ class V1Adapter
   rescue WIN32OLERuntimeError => err
     raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
     nil
+  end
+
+  # Returns a Win32OLE Trigger Object for the trigger at the given index for the
+  # supplied definition.
+  #
+  # Returns nil if the index does not exist
+  #
+  # Note - This is a 1 based array (not zero)
+  #
+  def trigger_at(index)
+    result = nil
+
+    begin
+      result = @definition.Triggers.Item(index)
+    rescue WIN32OLERuntimeError => err
+      raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
+      result = nil
+    end
+
+    result
   end
 end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -190,7 +190,7 @@ class V1Adapter
   def default_action(create_if_missing: false)
     action = nil
     (1..@definition.Actions.count).each do |i|
-      index_action = TaskScheduler2.action(@definition, i)
+      index_action = action_at(i)
       action = index_action if index_action.Type == TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC
       break if action
     end
@@ -200,6 +200,19 @@ class V1Adapter
     end
 
     action
+  end
+
+  def action_at(index)
+    result = nil
+
+    begin
+      result = @definition.Actions.Item(index)
+    rescue WIN32OLERuntimeError => err
+      raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
+      result = nil
+    end
+
+    result
   end
 end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -189,14 +189,14 @@ class V1Adapter
   # Find the first TASK_ACTION_EXEC action
   def default_action(create_if_missing: false)
     action = nil
-    (1..TaskScheduler2.action_count(@definition)).each do |i|
+    (1..@definition.Actions.count).each do |i|
       index_action = TaskScheduler2.action(@definition, i)
       action = index_action if index_action.Type == TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC
       break if action
     end
 
     if action.nil? && create_if_missing
-      action = TaskScheduler2.create_action(@definition, TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC)
+      action = @definition.Actions.Create(TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC)
     end
 
     action

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -135,11 +135,12 @@ class V1Adapter
   end
 
   def compatibility
-    TaskScheduler2.compatibility(@definition)
+    @definition.Settings.Compatibility
   end
 
   def compatibility=(value)
-    TaskScheduler2.set_compatibility(@definition, value)
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/aa381846(v=vs.85).aspx
+    @definition.Settings.Compatibility = value
   end
 
   # Returns the number of triggers associated with the active task.

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -203,16 +203,10 @@ class V1Adapter
   end
 
   def action_at(index)
-    result = nil
-
-    begin
-      result = @definition.Actions.Item(index)
-    rescue WIN32OLERuntimeError => err
-      raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
-      result = nil
-    end
-
-    result
+    @definition.Actions.Item(index)
+  rescue WIN32OLERuntimeError => err
+    raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
+    nil
   end
 end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -146,7 +146,7 @@ class V1Adapter
   # Returns the number of triggers associated with the active task.
   #
   def trigger_count
-    TaskScheduler2.trigger_count(@definition)
+    @definition.Triggers.count
   end
 
   # Deletes the trigger at the specified index.

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -56,8 +56,8 @@ class V1Adapter
   # The .job file itself is typically stored in the C:\WINDOWS\Tasks folder.
   #
   def save
-    task_object = @task.nil? ? @full_task_path : @task
-    TaskScheduler2.save(task_object, @definition, @task_password)
+    saved = TaskScheduler2.save(@task || @full_task_path, @definition, @task_password)
+    @task ||= saved
   end
 
   # Sets the +user+ and +password+ for the given task. If the user and

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -19,10 +19,8 @@ class V1Adapter
     raise TypeError unless task_name.is_a?(String)
 
     @full_task_path = TaskScheduler2::ROOT_FOLDER + task_name
-    @task = TaskScheduler2.task(@full_task_path)
-    @definition = @task.nil? ?
-      TaskScheduler2.new_task_definition :
-      TaskScheduler2.task_definition(@task)
+    # definition populated when task exists, otherwise new
+    @task, @definition = TaskScheduler2.task(@full_task_path)
     @task_password = nil
 
     self.compatibility = TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V1

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -220,16 +220,10 @@ class V1Adapter
   # Note - This is a 1 based array (not zero)
   #
   def trigger_at(index)
-    result = nil
-
-    begin
-      result = @definition.Triggers.Item(index)
-    rescue WIN32OLERuntimeError => err
-      raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
-      result = nil
-    end
-
-    result
+    @definition.Triggers.Item(index)
+  rescue WIN32OLERuntimeError => err
+    raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
+    nil
   end
 end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -83,7 +83,7 @@ class V1Adapter
   # been associated with the task.
   #
   def account_information
-    principal = TaskScheduler2.principal(@definition)
+    principal = @definition.Principal
     principal.nil? ? nil : principal.UserId
   end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -206,7 +206,7 @@ class V1Adapter
   def action_at(index)
     @definition.Actions.Item(index)
   rescue WIN32OLERuntimeError => err
-    raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
+    raise unless TaskScheduler2::Error.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
     nil
   end
 
@@ -220,7 +220,7 @@ class V1Adapter
   def trigger_at(index)
     @definition.Triggers.Item(index)
   rescue WIN32OLERuntimeError => err
-    raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
+    raise unless TaskScheduler2::Error.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
     nil
   end
 end

--- a/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v1adapter.rb
@@ -154,7 +154,10 @@ class V1Adapter
   def delete_trigger(index)
     # The older V1 API uses a starting index of zero, wherease the V2 API uses one.
     # Need to increment by one to maintain the same behavior
-    TaskScheduler2.delete_trigger(@definition, index + 1)
+    index += 1
+    @definition.Triggers.Remove(index)
+
+    index
   end
 
   # Returns a hash that describes the trigger at the given index for the

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -16,10 +16,8 @@ class V2Adapter
     raise TypeError unless task_name.is_a?(String)
 
     @full_task_path = TaskScheduler2::ROOT_FOLDER + task_name
-    @task = TaskScheduler2.task(@full_task_path)
-    @definition = @task.nil? ?
-      TaskScheduler2.new_task_definition :
-      TaskScheduler2.task_definition(@task)
+    # definition populated when task exists, otherwise new
+    @task, @definition = TaskScheduler2.task(@full_task_path)
     @task_password = nil
 
     set_account_information('',nil)

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -204,16 +204,10 @@ class V2Adapter
   end
 
   def action_at(index)
-    result = nil
-
-    begin
-      result = @definition.Actions.Item(index)
-    rescue WIN32OLERuntimeError => err
-      raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
-      result = nil
-    end
-
-    result
+    @definition.Actions.Item(index)
+  rescue WIN32OLERuntimeError => err
+    raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
+    nil
   end
 end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -191,7 +191,7 @@ class V2Adapter
   def default_action(create_if_missing: false)
     action = nil
     (1..@definition.Actions.count).each do |i|
-      index_action = TaskScheduler2.action(@definition, i)
+      index_action = action_at(i)
       action = index_action if index_action.Type == TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC
       break if action
     end
@@ -201,6 +201,19 @@ class V2Adapter
     end
 
     action
+  end
+
+  def action_at(index)
+    result = nil
+
+    begin
+      result = @definition.Actions.Item(index)
+    rescue WIN32OLERuntimeError => err
+      raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
+      result = nil
+    end
+
+    result
   end
 end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -142,11 +142,12 @@ class V2Adapter
   end
 
   def compatibility
-    TaskScheduler2.compatibility(@definition)
+    @definition.Settings.Compatibility
   end
 
   def compatibility=(value)
-    TaskScheduler2.set_compatibility(@definition, value)
+    # https://msdn.microsoft.com/en-us/library/windows/desktop/aa381846(v=vs.85).aspx
+    @definition.Settings.Compatibility = value
   end
 
   # Deletes the trigger at the specified index.

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -135,12 +135,6 @@ class V2Adapter
     dir
   end
 
-  # Returns the number of triggers associated with the active task.
-  #
-  def trigger_count
-    TaskScheduler2.trigger_count(@definition)
-  end
-
   def compatibility
     @definition.Settings.Compatibility
   end
@@ -148,6 +142,12 @@ class V2Adapter
   def compatibility=(value)
     # https://msdn.microsoft.com/en-us/library/windows/desktop/aa381846(v=vs.85).aspx
     @definition.Settings.Compatibility = value
+  end
+
+  # Returns the number of triggers associated with the active task.
+  #
+  def trigger_count
+    @definition.Triggers.count
   end
 
   # Deletes the trigger at the specified index.

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -221,16 +221,10 @@ class V2Adapter
   # Note - This is a 1 based array (not zero)
   #
   def trigger_at(index)
-    result = nil
-
-    begin
-      result = @definition.Triggers.Item(index)
-    rescue WIN32OLERuntimeError => err
-      raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
-      result = nil
-    end
-
-    result
+    @definition.Triggers.Item(index)
+  rescue WIN32OLERuntimeError => err
+    raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
+    nil
   end
 end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -84,7 +84,7 @@ class V2Adapter
   # been associated with the task.
   #
   def account_information
-    principal = TaskScheduler2.principal(@definition)
+    principal = @definition.Principal
     principal.nil? ? nil : principal.UserId
   end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -57,8 +57,8 @@ class V2Adapter
   # The .job file itself is typically stored in the C:\WINDOWS\Tasks folder.
   #
   def save
-    task_object = @task.nil? ? @full_task_path : @task
-    TaskScheduler2.save(task_object, @definition, @task_password)
+    saved = TaskScheduler2.save(@task || @full_task_path, @definition, @task_password)
+    @task ||= saved
   end
 
   # Sets the +user+ and +password+ for the given task. If the user and

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -155,7 +155,10 @@ class V2Adapter
   def delete_trigger(index)
     # The older V1 API uses a starting index of zero, wherease the V2 API uses one.
     # Need to increment by one to maintain the same behavior
-    TaskScheduler2.delete_trigger(@definition, index + 1)
+    index += 1
+    @definition.Triggers.Remove(index)
+
+    index
   end
 
   # Returns a hash that describes the trigger at the given index for the

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -167,7 +167,7 @@ class V2Adapter
   def trigger(index)
     # The older V1 API uses a starting index of zero, wherease the V2 API uses one.
     # Need to increment by one to maintain the same behavior
-    trigger_object = TaskScheduler2.trigger(@definition, index + 1)
+    trigger_object = trigger_at(index + 1)
     trigger_object.nil? || Trigger::V2::TYPE_MANIFEST_MAP[trigger_object.Type].nil? ?
       nil :
       Trigger::V2.to_manifest_hash(trigger_object)
@@ -211,6 +211,26 @@ class V2Adapter
   rescue WIN32OLERuntimeError => err
     raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
     nil
+  end
+
+  # Returns a Win32OLE Trigger Object for the trigger at the given index for the
+  # supplied definition.
+  #
+  # Returns nil if the index does not exist
+  #
+  # Note - This is a 1 based array (not zero)
+  #
+  def trigger_at(index)
+    result = nil
+
+    begin
+      result = @definition.Triggers.Item(index)
+    rescue WIN32OLERuntimeError => err
+      raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
+      result = nil
+    end
+
+    result
   end
 end
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -207,7 +207,7 @@ class V2Adapter
   def action_at(index)
     @definition.Actions.Item(index)
   rescue WIN32OLERuntimeError => err
-    raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
+    raise unless TaskScheduler2::Error.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
     nil
   end
 
@@ -221,7 +221,7 @@ class V2Adapter
   def trigger_at(index)
     @definition.Triggers.Item(index)
   rescue WIN32OLERuntimeError => err
-    raise unless TaskScheduler2.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
+    raise unless TaskScheduler2::Error.is_com_error_type(err, TaskScheduler2::Error::E_INVALIDARG)
     nil
   end
 end

--- a/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/v2adapter.rb
@@ -190,14 +190,14 @@ class V2Adapter
   # Find the first TASK_ACTION_EXEC action
   def default_action(create_if_missing: false)
     action = nil
-    (1..TaskScheduler2.action_count(@definition)).each do |i|
+    (1..@definition.Actions.count).each do |i|
       index_action = TaskScheduler2.action(@definition, i)
       action = index_action if index_action.Type == TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC
       break if action
     end
 
     if action.nil? && create_if_missing
-      action = TaskScheduler2.create_action(@definition, TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC)
+      action = @definition.Actions.Create(TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC)
     end
 
     action

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
@@ -29,7 +29,7 @@ ST = PuppetX::PuppetLabs::ScheduledTask
 def create_test_task(task_name = nil, task_compatiblity = ST::TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V2)
   tasksched = ST::TaskScheduler2
   task_name = tasksched::ROOT_FOLDER + 'puppet_task_' + SecureRandom.uuid.to_s if task_name.nil?
-  definition = tasksched.new_task_definition
+  _, definition = tasksched.task(task_name)
   # Set task settings
   definition.Settings.Compatibility = task_compatiblity
   tasksched.set_principal(definition, '')
@@ -119,8 +119,9 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2", :if => Puppet.fea
       PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2.delete(@task_name)
     end
 
-    let(:task_object) { subject.task(@task_name) }
-    let(:task_definition) { subject.task_definition(task_object) }
+    let(:task_return) { subject.task(@task_name) }
+    let(:task_object) { task_return[0] }
+    let(:task_definition) { task_return[1] }
 
     context 'given a test task fixture' do
       it 'should be disabled' do
@@ -172,8 +173,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2", :if => Puppet.fea
         # using path and name
         ps_cmd = '(Get-ScheduledTask | ? { $_.TaskPath + $_.TaskName -eq \'' + @task_name + '\' }).Actions[0].Execute'
 
-        task_object = subject.task(@task_name)
-        task_definition = subject.task_definition(task_object)
+        task_object, task_definition = subject.task(@task_name)
         expect('cmd.exe').to be_same_as_powershell_command(ps_cmd)
 
         task_definition.Actions.Item(1).Path = 'notepad.exe'

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
@@ -144,15 +144,15 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2", :if => Puppet.fea
       end
 
       it 'should have an action of type Execution' do
-        expect(subject.action(task_definition, 1).Type).to eq(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC)
+        expect(task_definition.Actions.Item(1).Type).to eq(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_ACTION_TYPE::TASK_ACTION_EXEC)
       end
 
       it 'should have the specified action path' do
-        expect(subject.action(task_definition, 1).Path).to eq('cmd.exe')
+        expect(task_definition.Actions.Item(1).Path).to eq('cmd.exe')
       end
 
       it 'should have the specified action arguments' do
-        expect(subject.action(task_definition, 1).Arguments).to eq('/c exit 0')
+        expect(task_definition.Actions.Item(1).Arguments).to eq('/c exit 0')
       end
     end
   end
@@ -176,7 +176,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2", :if => Puppet.fea
         task_definition = subject.task_definition(task_object)
         expect('cmd.exe').to be_same_as_powershell_command(ps_cmd)
 
-        subject.action(task_definition, 1).Path = 'notepad.exe'
+        task_definition.Actions.Item(1).Path = 'notepad.exe'
         subject.save(task_object, task_definition)
         expect('notepad.exe').to be_same_as_powershell_command(ps_cmd)
       end

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
@@ -31,7 +31,7 @@ def create_test_task(task_name = nil, task_compatiblity = ST::TaskScheduler2::TA
   task_name = tasksched::ROOT_FOLDER + 'puppet_task_' + SecureRandom.uuid.to_s if task_name.nil?
   definition = tasksched.new_task_definition
   # Set task settings
-  tasksched.set_compatibility(definition, task_compatiblity)
+  definition.Settings.Compatibility = task_compatiblity
   tasksched.set_principal(definition, '')
   definition.Settings.Enabled = false
   # Create a trigger
@@ -128,7 +128,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2", :if => Puppet.fea
       end
 
       it 'should be V2 compatible' do
-        expect(subject.compatibility(task_definition)).to eq(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V2)
+        expect(task_definition.Settings.Compatibility).to eq(PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2::TASK_COMPATIBILITY::TASK_COMPATIBILITY_V2)
       end
 
       it 'should have a single trigger' do

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
@@ -132,7 +132,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2", :if => Puppet.fea
       end
 
       it 'should have a single trigger' do
-        expect(subject.trigger_count(task_definition)).to eq(1)
+        expect(task_definition.Triggers.count).to eq(1)
       end
 
       it 'should have a trigger of type TimeTrigger' do

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
@@ -136,7 +136,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2", :if => Puppet.fea
       end
 
       it 'should have a trigger of type TimeTrigger' do
-        expect(subject.trigger(task_definition, 1).Type).to eq(ST::Trigger::V2::Type::TASK_TRIGGER_TIME)
+        expect(task_definition.Triggers.Item(1).Type).to eq(ST::Trigger::V2::Type::TASK_TRIGGER_TIME)
       end
 
       it 'should have a single action' do

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/taskscheduler2_spec.rb
@@ -38,7 +38,7 @@ def create_test_task(task_name = nil, task_compatiblity = ST::TaskScheduler2::TA
   trigger = definition.Triggers.Create(ST::Trigger::V2::Type::TASK_TRIGGER_TIME)
   trigger.StartBoundary = '2017-09-11T14:02:00'
   # Create an action
-  new_action = tasksched.create_action(definition, tasksched::TASK_ACTION_TYPE::TASK_ACTION_EXEC)
+  new_action = definition.Actions.Create(tasksched::TASK_ACTION_TYPE::TASK_ACTION_EXEC)
   new_action.Path = 'cmd.exe'
   new_action.Arguments = '/c exit 0'
   tasksched.save(task_name, definition)
@@ -140,7 +140,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2", :if => Puppet.fea
       end
 
       it 'should have a single action' do
-        expect(subject.action_count(task_definition)).to eq(1)
+        expect(task_definition.Actions.Count).to eq(1)
       end
 
       it 'should have an action of type Execution' do

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/v1adapter_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/v1adapter_spec.rb
@@ -94,7 +94,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::V1Adapter", :if => Puppet.features
         task_object = subjectv2.new('foo')
         # guarantee task not saved to system
         task_object.stubs(:save)
-        PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2.expects(:trigger).returns(stub(trigger_details))
+        task_object.expects(:trigger_at).with(1).returns(stub(trigger_details))
 
         expect(task_object.trigger(0)).to be_nil
       end

--- a/spec/integration/puppet_x/puppetlabs/scheduled_task/v2adapter_spec.rb
+++ b/spec/integration/puppet_x/puppetlabs/scheduled_task/v2adapter_spec.rb
@@ -78,7 +78,7 @@ describe "PuppetX::PuppetLabs::ScheduledTask::V2Adapter", :if => Puppet.features
         task_object = subject.new('foo')
         # guarantee task not saved to system
         task_object.stubs(:save)
-        PuppetX::PuppetLabs::ScheduledTask::TaskScheduler2.expects(:trigger).returns(stub(trigger_details))
+        task_object.expects(:trigger_at).with(1).returns(stub(trigger_details))
 
         expect(task_object.trigger(0)).to be_nil
       end


### PR DESCRIPTION
~~Builds on #51, which should be merged first~~

Removes a number of code paths from `TaskScheduler2` that were unnecessary and/or unnecessarily complex. Many of these methods took a `definition` object and only performed a single action with it, and could easily be inlined into the two adapter classes.

This is the first part of a class restructuring that will:

* Merge the 2 adapter classes into a single base implementation (since they share 99% of their impl)
* Potentially refactor remaining methods from `TaskScheduler2` directly into the base adapter class (there's only about 120 lines of actual code in `TaskScheduler2` module now - and it would probably be fine)
* Ultimately this should simplify the class hierarchy so that maintenance is simpler