### PR TITLE
(MODULES-7651) Remove spec folder from builds

### DIFF
--- a/.pdkignore
+++ b/.pdkignore
@@ -15,6 +15,7 @@
 /junit/
 /log/
 /pkg/
+/spec/
 /spec/fixtures/manifests/
 /spec/fixtures/modules/
 /tmp/

--- a/.pmtignore
+++ b/.pmtignore
@@ -4,6 +4,7 @@ Gemfile.lock
 Gemfile.local
 vendor/
 .vendor/
+spec/
 spec/fixtures/manifests/
 spec/fixtures/modules/
 .vagrant/


### PR DESCRIPTION
- The PDK looks at .pdkignore to determine what to include / exclude
   with the built tarball - see

   puppetlabs/pdk:lib/pdk/module/build.rb@c6db211#L176-L182

 - PMT (Puppet module tool) looks at .pmtignore for the same thing,
   which is how a module is typically bundled in CI or through a
   local workflow with `bundle exec rake build`
