### PR TITLE
(MODULES-7240) Setting User For A Task Fails

### DIFF
--- a/lib/puppet_x/puppetlabs/scheduled_task/task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/task.rb
@@ -113,13 +113,13 @@ class Task
     @full_task_path = ROOT_FOLDER + task_name
     # definition populated when task exists, otherwise new
     @task, @definition = self.class.task(@full_task_path)
-    @task_password = nil
+    task_userid = @definition.Principal.UserId || ''
 
     if compatibility_level == :v1_compatibility
       self.compatibility = TASK_COMPATIBILITY::TASK_COMPATIBILITY_V1
     end
 
-    set_account_information('',nil)
+    set_account_information(task_userid,nil)
   end
 
   V1_COMPATIBILITY = [
@@ -209,7 +209,7 @@ class Task
       when TASK_LOGON_TYPE::TASK_LOGON_PASSWORD,
         TASK_LOGON_TYPE::TASK_LOGON_INTERACTIVE_TOKEN_OR_PASSWORD
         task_user = @definition.Principal.UserId
-        task_password = @password
+        task_password = @task_password
     end
 
     saved = task_folder.RegisterTaskDefinition(

--- a/spec/acceptance/should_create_task_spec.rb
+++ b/spec/acceptance/should_create_task_spec.rb
@@ -4,6 +4,16 @@ host = find_only_one("default")
 
 describe "Should create a scheduled task", :node => host do
 
+  before(:all) do
+    @username, @password = add_test_user(host)
+    @username2, @password2 = add_test_user(host)
+  end
+
+  after(:all) do
+    remove_test_user(host, @username)
+    remove_test_user(host, @username2)
+  end
+
   before(:each) do
     @taskname = "pl#{rand(999999).to_i}"
   end
@@ -18,7 +28,7 @@ describe "Should create a scheduled task", :node => host do
     end
   end
 
-  it "Should create a task if it does not exist", :tier_high => true do
+  it "Should create a task if it does not exist: taskscheduler_api2", :tier_high => true do
     pp = <<-MANIFEST
     scheduled_task {'#{@taskname}':
       ensure      => present,
@@ -43,7 +53,7 @@ describe "Should create a scheduled task", :node => host do
     on(host, query_cmd)
   end
 
-  it "Should create a task if it does not exist", :tier_high => true do
+  it "Should create a task if it does not exist: win32_taskscheduler", :tier_high => true do
     pp = <<-MANIFEST
     scheduled_task {'#{@taskname}':
       ensure        => present,
@@ -66,5 +76,155 @@ describe "Should create a scheduled task", :node => host do
     # Verify the task exists
     query_cmd = "schtasks.exe /query /v /fo list /tn #{@taskname}"
     on(host, query_cmd)
+  end
+
+  it "Should create a task with a username and password: taskscheduler_api2" do
+    pp = <<-MANIFEST
+    scheduled_task {'#{@taskname}':
+      ensure        => present,
+      command       => 'c:\\\\windows\\\\system32\\\\notepad.exe',
+      arguments     => "foo bar baz",
+      working_dir   => 'c:\\\\windows',
+      user          => '#{@username}',
+      password      => '#{@password}',
+      trigger       => {
+        schedule   => daily,
+        start_time => '12:00',
+      },
+    }
+    MANIFEST
+    execute_manifest(pp, :catch_failures => true)
+
+    # Verify the task exists
+    query_cmd = "schtasks.exe /query /v /fo list /tn #{@taskname}"
+    result = on(host, query_cmd)
+
+    # Verify the task is running under the correct user
+    result.stdout.match?(@username)
+  end
+
+  it "Should create a task with a username and password: win32_taskscheduler" do
+    pp = <<-MANIFEST
+    scheduled_task {'#{@taskname}':
+      ensure        => present,
+      command       => 'c:\\\\windows\\\\system32\\\\notepad.exe',
+      arguments     => "foo bar baz",
+      working_dir   => 'c:\\\\windows',
+      user          => '#{@username}',
+      password      => '#{@password}',
+      trigger       => {
+        schedule   => daily,
+        start_time => '12:00',
+      },
+      provider      => 'win32_taskscheduler'
+    }
+    MANIFEST
+    execute_manifest(pp, :catch_failures => true)
+
+    # Verify the task exists
+    query_cmd = "schtasks.exe /query /v /fo list /tn #{@taskname}"
+    result = on(host, query_cmd)
+
+    # Verify the task is running under the correct user
+    result.stdout.match?(@username)
+  end
+
+  it "Should update a task's credentials: win32_taskscheduler" do
+    pp = <<-MANIFEST
+    scheduled_task {'#{@taskname}':
+      ensure        => present,
+      command       => 'c:\\\\windows\\\\system32\\\\notepad.exe',
+      arguments     => "foo bar baz",
+      working_dir   => 'c:\\\\windows',
+      user          => '#{@username}',
+      password      => '#{@password}',
+      trigger       => {
+        schedule   => daily,
+        start_time => '12:00',
+      },
+      provider      => 'win32_taskscheduler'
+    }
+    MANIFEST
+    execute_manifest(pp, :catch_failures => true)
+
+    # Verify the task exists
+    query_cmd = "schtasks.exe /query /v /fo list /tn #{@taskname}"
+    result = on(host, query_cmd)
+
+    # Verify the task is running under the correct user
+    result.stdout.match?(@username)
+
+    pp = <<-MANIFEST
+    scheduled_task {'#{@taskname}':
+      ensure        => present,
+      compatibility => 1,
+      command       => 'c:\\\\windows\\\\system32\\\\notepad.exe',
+      arguments     => "foo bar baz",
+      working_dir   => 'c:\\\\windows',
+      user          => '#{@username2}',
+      password      => '#{@password2}',
+      trigger       => {
+        schedule   => daily,
+        start_time => '12:00',
+      },
+      provider      => 'win32_taskscheduler'
+    }
+    MANIFEST
+    execute_manifest(pp, :catch_failures => true)
+
+    # Verify the task exists
+    query_cmd = "schtasks.exe /query /v /fo list /tn #{@taskname}"
+    result = on(host, query_cmd)
+
+    # Verify the task is running under the correct user
+    result.stdout.match?(@username2)
+  end
+
+  it "Should update a task's credentials: taskscheduler_api2" do
+    pp = <<-MANIFEST
+    scheduled_task {'#{@taskname}':
+      ensure        => present,
+      command       => 'c:\\\\windows\\\\system32\\\\notepad.exe',
+      arguments     => "foo bar baz",
+      working_dir   => 'c:\\\\windows',
+      user          => '#{@username}',
+      password      => '#{@password}',
+      trigger       => {
+        schedule   => daily,
+        start_time => '12:00',
+      },
+    }
+    MANIFEST
+    execute_manifest(pp, :catch_failures => true)
+
+    # Verify the task exists
+    query_cmd = "schtasks.exe /query /v /fo list /tn #{@taskname}"
+    result = on(host, query_cmd)
+
+    # Verify the task is running under the correct user
+    result.stdout.match?(@username)
+
+    pp = <<-MANIFEST
+    scheduled_task {'#{@taskname}':
+      ensure        => present,
+      command       => 'c:\\\\windows\\\\system32\\\\notepad.exe',
+      arguments     => "foo bar baz",
+      working_dir   => 'c:\\\\windows',
+      user          => '#{@username2}',
+      password      => '#{@password2}',
+      trigger       => {
+        schedule   => daily,
+        start_time => '12:00',
+      },
+    }
+    MANIFEST
+    execute_manifest(pp, :catch_failures => true)
+
+    # Verify the task exists
+    query_cmd = "schtasks.exe /query /v /fo list /tn #{@taskname}"
+    result = on(host, query_cmd)
+
+    # Verify the task is running under the correct user
+    result.stdout.match?(@username2)
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -18,3 +18,24 @@ end
 def windows_agents
   agents.select { |agent| agent['platform'].include?('windows') }
 end
+
+def add_test_user(host)
+  username = "test_user_#{rand(999).to_i}"
+  password = "password!@#123"
+
+  command_string = "net user /add #{username} #{password}"
+
+  on(host, command_string) do |r|
+    raise r.stderr unless r.stderr.empty?
+  end
+
+  [username, password]
+end
+
+def remove_test_user(host, username)
+  command_string = "net user /delete #{username}"
+
+  on(host, command_string) do |r|
+    raise r.stderr unless r.stderr.empty?
+  end
+end


### PR DESCRIPTION
Prior to this change, if a manifest specified a user and a password to
run a task, those settings were not respected. Puppet's commandline
logging would first claim that a task was create, but then throw an OLE
error.

This change ensures that a username and password can successfully be
specified for a task.