### PR TITLE
(maint) Memoize the Schedule.Service COM instance

### DIFF
--- a/lib/puppet_x/puppetlabs/scheduled_task/task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/task.rb
@@ -354,10 +354,12 @@ class Task
   private
   # :stopdoc:
   def self.task_service
-    service = WIN32OLE.new('Schedule.Service')
-    service.connect()
+    return @service unless @service.nil?
 
-    service
+    @service = WIN32OLE.new('Schedule.Service')
+    @service.connect()
+
+    @service
   end
 
   def self.task_name_from_task_path(task_path)


### PR DESCRIPTION
 - Currently, a new Service instance is created each time:

   * The task method is called to load a task, which is in turn
     called by the initializer for Task
   * For each depth of the folder hierarchy for enum_task_names,
     which is called when retrieving all tasks
   * When a task is deleted
   * When a task is saved

 - This generates a lot of unnecessary object creation overhead and
   can be minimized by memoizing the first created instance