### PR TITLE
(MODULES-7203) Support nonroot task folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Added
+
+- Ability to specify scheduled tasks in subfolders by prepending the folder path to the task name ([MODULES-7203](https://tickets.puppetlabs.com/browse/.MODULES-7203)).
+
 ## [1.0.1] - 2019-03-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ All attributes except `name`, `command`, and `trigger` are optional; see the des
 
 The name assigned to the scheduled task.
 This will uniquely identify the task on the system.
+If specifying a scheduled task inside of subfolder(s), specify the path from root, such as `subfolder/mytaskname`.
+This will create the scheduled task `mytaskname` in the container named `subfolder`.
+You can only specify a taskname inside of subfolders if the compatibility is set to 2 or higher and when using the taskscheduler2_api provider.
 
 ##### `ensure`
 

--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -207,4 +207,10 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
 
     true
   end
+
+  def validate_name
+    if @resource[:name].match?(/\\/) && @resource[:compatibility] < 2
+      raise Puppet::ResourceError, "#{@resource[:name]} specifies a path including subfolders and a compatibility of #{@resource[:compatibility]} - tasks in subfolders are only supported on version 2 and later of the API. Specify a compatibility of 2 or higher or do not specify a subfolder path."
+    end
+  end
 end

--- a/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
+++ b/lib/puppet/provider/scheduled_task/win32_taskscheduler.rb
@@ -196,4 +196,10 @@ Puppet::Type.type(:scheduled_task).provide(:win32_taskscheduler) do
 
     true
   end
+
+  def validate_name
+    if @resource[:name].match?(/\\/)
+      raise Puppet::ResourceError, "#{@resource[:name]} specifies a path including subfolders which are not supported by the version of the Task Scheduler API used by this provider. Use the taskscheduler_api2 provider instead."
+    end
+  end
 end

--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -22,8 +22,13 @@ Puppet::Type.newtype(:scheduled_task) do
   end
 
   newparam(:name) do
-    desc "The name assigned to the scheduled task.  This will uniquely
-      identify the task on the system."
+    desc "The name assigned to the scheduled task. This will uniquely
+      identify the task on the system. If specifying a scheduled task
+      inside of subfolder(s), specify the path from root, such as
+      `subfolder/mytaskname`. This will create the scheduled task
+      `mytaskname` in the container named `subfolder`. You can only
+      specify a taskname inside of subfolders if the compatibility is
+      set to 2 or higher and when using the taskscheduler2_api provider."
 
     isnamevar
   end
@@ -243,5 +248,9 @@ Puppet::Type.newtype(:scheduled_task) do
     def is_to_s(current_value=@is)
       super(current_value)
     end
+  end
+
+  validate do
+    provider.validate_name if provider.respond_to?(:validate_name)
   end
 end


### PR DESCRIPTION
Prior to this commit the type and providers did not support specifying subfolders in which
to place a scheduled task. This commit adds support to the type and the taskscheduler_api2
provider for specifying scheduled tasks in subfolders.

This feature only exists for tasks whose compatibility is 2 or higher which prevents it from
being used on the legacy win32_taskscheduler provider altogether and necessitates some
validation prior to runtime.

This commit adds such validation by failing with descriptive errors during resource validation.

This new functionality requires the ability to scaffold folders in which to place the scheduled
task, which now happens automatically and only if the folder path does not already exist.

This commit does NOT add functionality for pruning the folders on task deletion, this should be
addressed in a future commit.

It does update the documentation and tests for the new feature as well as ensure all existing
tests continue to pass.