### PR TITLE
(MODULES-9749) Add release_prep gem group

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -15,7 +15,7 @@ Rakefile:
 
 Gemfile:
   optional:
-    ':development':
+    ':release_prep':
       - gem: 'github_changelog_generator'
         git: 'https://github.com/skywinder/github-changelog-generator'
         ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'

--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,9 @@ group :development do
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 0.3',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "github_changelog_generator",                              require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
+end
+group :release_prep do
+  gem "github_changelog_generator", require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -62,11 +62,16 @@ else
   task :changelog do
     raise <<EOM
 The changelog tasks depends on unreleased features of the github_changelog_generator gem.
-Please manually add it to your .sync.yml for now, and run `pdk update`:
+If you installed your gems without release_prep, you will want to ensure you bundle install
+without skipping that gem group.
+
+If you did not specify without release_prep during your bundle install, it is possible your
+gemfile does not include the gem. Please manually add it to your .sync.yml for now, and run 
+`pdk update`:
 ---
 Gemfile:
   optional:
-    ':development':
+    ':release_prep':
       - gem: 'github_changelog_generator'
         git: 'https://github.com/skywinder/github-changelog-generator'
         ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'


### PR DESCRIPTION
This commit adds the release_prep gem group to the sync.yml. This will
enable bundle installs without this gem in CI which should protect us
from dependency issues.