### PR TITLE
(MODULES-10241) Revert AppVeyor test exec to serial mode

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -8,6 +8,7 @@
   simplecov: true
 appveyor.yml:
   use_litmus: true
+  spec_type: spec
   matrix_extras:
   - RUBY_VERSION: 25-x64
     ACCEPTANCE: 'yes'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,19 +22,19 @@ environment:
     -
       PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24
-      CHECK: parallel_spec
+      CHECK: spec
     -
       PUPPET_GEM_VERSION: ~> 5.0
       RUBY_VERSION: 24-x64
-      CHECK: parallel_spec
+      CHECK: spec
     -
       PUPPET_GEM_VERSION: ~> 6.0
       RUBY_VERSION: 25
-      CHECK: parallel_spec
+      CHECK: spec
     -
       PUPPET_GEM_VERSION: ~> 6.0
       RUBY_VERSION: 25-x64
-      CHECK: parallel_spec
+      CHECK: spec
     -
       RUBY_VERSION: 25-x64
       ACCEPTANCE: yes

--- a/metadata.json
+++ b/metadata.json
@@ -35,5 +35,5 @@
   ],
   "pdk-version": "1.14.1",
   "template-url": "https://github.com/puppetlabs/pdk-templates#master",
-  "template-ref": "heads/master-0-gfaf9e8b"
+  "template-ref": "heads/master-0-g643529a"
 }


### PR DESCRIPTION
See full description [here](https://confluence.puppetlabs.com/display/ECO/Inability+to+run+puppetlabs-scheduled_task+in+rspec_parallel+mode). To summarise:

- `parallel_spec` was enabled as part of this PR: https://github.com/puppetlabs/puppetlabs-scheduled_task/pull/104
- This caused AppVeyor CI tests failures
- It was discovered that the tests within [task_spec.rb](https://github.com/puppetlabs/puppetlabs-scheduled_task/blob/e5fc25063716e857dd2dc4d169d1de85a9adb2a8/spec/integration/puppet_x/puppetlabs/scheduled_task/task_spec.rb) are not thread safe
- Tests are modifying the scheduled task configuration via the Puppet Agent, whilst the [results are being read back from PowerShell](https://github.com/puppetlabs/puppetlabs-scheduled_task/blob/e5fc25063716e857dd2dc4d169d1de85a9adb2a8/spec/integration/puppet_x/puppetlabs/scheduled_task/task_spec.rb#L9-L26) to verify each test had been successful