### PR TITLE
(maint) Update spec test error message expectations

### DIFF
--- a/spec/acceptance/should_destroy_spec.rb
+++ b/spec/acceptance/should_destroy_spec.rb
@@ -37,7 +37,7 @@ describe 'Should destroy a scheduled task', node: host do
 
       query_cmd = "schtasks.exe /query /v /fo list /tn #{taskname}"
       query_out = run_shell(query_cmd, expect_failures: true)
-      expect(query_out.to_s).to match(%r{ERROR: The system cannot find the file specified})
+      expect(query_out.to_s).to match(%r{ERROR: The system cannot find the (file|path) specified})
     end
   end
 end


### PR DESCRIPTION
Encountering errors on AppVeyor as the error message being returned for [this negative test](https://github.com/puppetlabs/puppetlabs-scheduled_task/pull/116/files#diff-a5b71a8a826396d01399d7e2c62fa515R40) is:
```
ERROR: The system cannot find the path specified.
```
whereas the test is expecting the error:
```
ERROR: The system cannot find the file specified.
```

Still need investigation as to why there is a difference in the error message ("file" vs "path"). Unable to reproduce with Windows images provisioned locally (tried on Server 2008 R2 and Server 2016). There may be something unique to AppVeyor's particular images.