### PR TITLE
(MODULES-10101) Use RunOnLastWeekOfMonth for which_occurrence = last

### DIFF
--- a/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/trigger.rb
@@ -716,6 +716,9 @@ module PuppetX::PuppetLabs::ScheduledTask
                                # HACK: choose only the first week selected when converting - this LOSES information
                                'which_occurrence' => occurrences.first || '',
                                'day_of_week'      => Day.bitmask_to_names(i_trigger.DaysOfWeek))
+          # MODULES-10101: We will need to evaluate whether the value 'last' has been applied to the WeekOfMonth
+          # parameter by inspecting the value of Trigger::RunOnLastWeekOfMonth. See JIRA ticket for more details.
+          manifest_hash['which_occurrence'] = 'last' if i_trigger.RunOnLastWeekOfMonth
         when Type::TASK_TRIGGER_BOOT
           manifest_hash['schedule'] = 'boot'
         when Type::TASK_TRIGGER_LOGON


### PR DESCRIPTION
### Description
We were not correctly determining the idempotency of a scheduled task that had a [MonthlyDOWTrigger](https://docs.microsoft.com/en-gb/windows/win32/taskschd/monthlydowtrigger) set to `last`:
```
'which_occurrence' => 'last'
```
The task was being correctly set on the Windows Server instances, but when we read back the task, we were determining that the `Task.Definition.Triggers[i].WeeksOfMonth` attribute was `0` (i.e. nothing defined). Instead, we should be checking the [RunOnLastWeekOfMonth](https://docs.microsoft.com/en-gb/windows/win32/taskschd/monthlydowtrigger-runonlastweekofmonth) to determine if the task is set to run on the last week of the month.

**NOTE:** We are not changing how this parameter is configured, just how it is read back.
### Tests
- [x] `pdk validate` successfully passes
- [x] Existing acceptance tests pass on all compatible OSs
- [x] New acceptance tests pass on all compatible OSs