### PR TITLE
replace puppet[:compatibility] with function call compatibility since…

### DIFF
--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -208,7 +208,7 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
   end
 
   def validate_name
-    return unless @resource[:name].match?(%r{\\}) && @resource[:compatibility] < 2
+    return unless @resource[:name].match?(%r{\\}) && compatibility < 2
 
     raise Puppet::ResourceError, "#{@resource[:name]} specifies a path including subfolders and a compatibility of #{@resource[:compatibility]}"\
                                  ' - tasks in subfolders are only supported on version 2 and later of the API. Specify a compatibility of 2 or higher or do not specify a subfolder path.'


### PR DESCRIPTION
Puppet resource command not working scheduled_task type and taskscheduler_api2 provider because validate uses @resource[:compatibility] variable which is not populated at the time the validation function is called. Replacing @resource[:compatibility] variable with call to compatibility method.

Error: Could not run: Validation of Scheduled_task[Microsoft\Configuration Manager\Configuration Manager Health Evaluation] failed: Microsoft\Configuration Manager\Configuration Manager Health Evaluation specifies a path including subfolders and a compatibility of 1 - tasks in subfolders are only supported on version 2 and later of the API. Specify a compatibility of 2 or higher or do not specify a subfolder path.