### PR TITLE
(MODULES-10893) Fix Last Day Of Month Trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,9 @@ For all triggers:
     Each month must be an integer between 1 and 12.
   * `on` (Required) — Which days of the month the task should run, as an array.
     Each day must be an integer between 1 and 31.
+    * The string `last` may be used in the array for this property to trigger a
+    task to run on the last day of each selected month. This feature is only
+    available for tasks with compatibility level `2` or higher.
 * For monthly (by weekday) triggers:
   * `months` — Which months the task should run, as an array. Defaults to all months. Each month must be an integer between 1 and 12.
   * `day_of_week` (Required) — Which day of the week the task should run, as an array with only one element.

--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -163,6 +163,7 @@ Puppet::Type.newtype(:scheduled_task) do
             all months. Each month must be an integer between 1 and 12.
           * `on` **(Required)** --- Which days of the month the task should run,
             as an array. Each day must be an integer between 1 and 31 or the string `last`.
+            The string `last` is only supported for tasks with level 2 compatibility or higher.
       * For `monthly` (by weekday) triggers:
           * `months` --- Which months the task should run, as an array. Defaults to
             all months. Each month must be an integer between 1 and 12.


### PR DESCRIPTION
Prior to this change, attempting to create a trigger that will run on
the last day of each selected month will fail. The error claims that a
a value is out of range

```
OLE error code:0 in <Unknown>
      <No Description>
    HRESULT error code:0x8002000a
      Out of present range.
```

Microsoft [documentation] claims in one place that the correct way to
specify the last day of a month is to effectively translate a bitmask
value of day 32 and pass that into the `{get:set}_DaysOfMonth` method
on the trigger object. The module was previously coded to do exactly
this. The provider and it's helpers would catch the string value 'last'
in the `on` property of a `monthly` trigger and translate it into the
bit mask. This is what resulted in the error, because it turns out that
the position for day 32 in the bit mast is outside the acceptable range
of values for this property.

This PR changes strategy and instead relies on a different section
of the documentation in which an entirely different property on the
trigger object called [RunOnLastDayOfMonth] is set.

The code now catches the string value 'last' in the `on` property of
the trigger, and sets this boolean on the trigger object.

Testing has shown this to be an effective method of managing this
property of a trigger.

[documentation]: https://docs.microsoft.com/en-gb/windows/win32/api/taskschd/nf-taskschd-imonthlytrigger-get_daysofmonth
[RunOnLastDayOfMonth]: https://docs.microsoft.com/en-gb/windows/win32/api/taskschd/nf-taskschd-imonthlytrigger-put_runonlastdayofmonth