### PR TITLE
(MODULES-10986) Fix gMSA username support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -197,9 +197,10 @@ Please also note that Puppet must be running as a privileged user
 in order to manage `scheduled_task` resources. Running as an
 unprivileged user will result in 'access denied' errors.
 
-If a user is specified without an accompanying password, the
-task will be created with `Run only when user is logged on`
-specified.
+If a user is specified without an accompanying password, and the
+user does not end with a dollar sign (`$`) signifying a Group
+Managed Service Account (gMSA), the task will be created with
+`Run only when user is logged on` specified.
 
 Default value: `system`
 

--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -79,9 +79,10 @@ Puppet::Type.newtype(:scheduled_task) do
       in order to manage `scheduled_task` resources. Running as an
       unprivileged user will result in 'access denied' errors.
 
-      If a user is specified without an accompanying password, the
-      task will be created with `Run only when user is logged on`
-      specified."
+      If a user is specified without an accompanying password, and the
+      user does not end with a dollar sign (`$`) signifying a Group
+      Managed Service Account (gMSA), the task will be created with
+      `Run only when user is logged on` specified."
 
     defaultto :system
 

--- a/lib/puppet_x/puppetlabs/scheduled_task/task.rb
+++ b/lib/puppet_x/puppetlabs/scheduled_task/task.rb
@@ -359,7 +359,7 @@ module PuppetX::PuppetLabs::ScheduledTask
         @definition.Principal.LogonType = TASK_LOGON_TYPE::TASK_LOGON_SERVICE_ACCOUNT
       else
         @definition.Principal.UserId = user
-        @definition.Principal.LogonType = if @task_password
+        @definition.Principal.LogonType = if @task_password || user[-1] == '$'
                                             TASK_LOGON_TYPE::TASK_LOGON_PASSWORD
                                           else
                                             TASK_LOGON_TYPE::TASK_LOGON_INTERACTIVE_TOKEN


### PR DESCRIPTION
Since the enhancement intended to help sysadmins, pulled in as #150: When not setting a password, this is interpreted as "Run only when user is logged on".

When configuring a scheduled task to use a Group Managed Service Account (gMSA) principal, there is no password to provide. The scheduler will get the password automatically when properly configured, and should be able to run the task even though the service account is not "logged on". Otherwise, the Managed Service Account is never "logged on" so the task does not run on expected schedule.

It does not seem viable to add a proper test case for this particular situation without an AD domain configuration and a proper gMSA in place. Without a correct gMSA, an error message stating "No mapping between account names and security IDs was done" appears to be returned.