### PR TITLE
(MAINT) Dropped support for Windows(7,8,8.1, 2008 Server and 2008 R2 Server)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "puppetlabs-scheduled_task",
   "version": "3.1.0",
   "author": "puppetlabs",
-  "summary": "Manage scheduled tasks for Windows Server 2008 and newer operating systems.",
+  "summary": "Manage scheduled tasks for Windows Server 2012 and newer operating systems.",
   "license": "Apache-2.0",
   "source": "git://github.com/puppetlabs/puppetlabs-scheduled_task",
   "project_page": "https://github.com/puppetlabs/puppetlabs-scheduled_task",
@@ -14,12 +14,7 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "7",
-        "8",
-        "8.1",
         "10",
-        "2008",
-        "2008 R2",
         "2012 R2",
         "2012",
         "2016",


### PR DESCRIPTION
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported. This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.

In this commit:
- Support for Windows Server 2008 and 2008 R2 was removed. 
- Support for Windows 7, 8 and 8.1 was removed.
﻿
The list of supported OSs can be found here:
https://puppet.com/docs/pe/2021.7/supported_operating_systems.html