### PR TITLE
[CAT-1382] : Fixing CI failure due to rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -160,6 +160,11 @@ RSpec/NoExpectationExample:
     - 'spec/unit/puppet/provider/scheduled_task/win32_taskscheduler_spec.rb'
     - 'spec/unit/puppet/type/scheduled_task_spec.rb'
 
+# Offense count: 1
+RSpec/SpecFilePathFormat:
+  Exclude:
+    - 'spec/unit/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb'
+
 # Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyle.

--- a/spec/acceptance/should_create_task_spec.rb
+++ b/spec/acceptance/should_create_task_spec.rb
@@ -25,7 +25,7 @@ describe 'Should create a scheduled task' do
     end
   end
 
-  it 'creates a task that runs on the last day of the month: taskscheduler_api2', tier_high: true do
+  it 'creates a task that runs on the last day of the month: taskscheduler_api2', :tier_high do
     pp = <<-MANIFEST
     scheduled_task {'#{taskname}':
       ensure      => present,
@@ -54,7 +54,7 @@ describe 'Should create a scheduled task' do
     end
   end
 
-  it 'creates a task if it does not exist: taskscheduler_api2', tier_high: true do
+  it 'creates a task if it does not exist: taskscheduler_api2', :tier_high do
     pp = <<-MANIFEST
     scheduled_task {'#{taskname}':
       ensure      => present,
@@ -77,7 +77,7 @@ describe 'Should create a scheduled task' do
     run_shell(query_cmd)
   end
 
-  it 'creates a task if it does not exist: win32_taskscheduler', tier_high: true do
+  it 'creates a task if it does not exist: win32_taskscheduler', :tier_high do
     pp = <<-MANIFEST
     scheduled_task {'#{taskname}':
       ensure        => present,
@@ -371,7 +371,7 @@ describe 'Should create a scheduled task' do
     end
   end
 
-  it 'creates a task with synchronisation disabled: taskscheduler_api2', tier_high: true do
+  it 'creates a task with synchronisation disabled: taskscheduler_api2', :tier_high do
     pp = <<-MANIFEST
     scheduled_task {'#{taskname}':
       ensure      => present,
@@ -394,7 +394,7 @@ describe 'Should create a scheduled task' do
     run_shell(query_cmd)
   end
 
-  it 'creates a task with synchronisation disabled: win32_taskscheduler', tier_high: true do
+  it 'creates a task with synchronisation disabled: win32_taskscheduler', :tier_high do
     pp = <<-MANIFEST
     scheduled_task {'#{taskname}':
       ensure        => present,

--- a/spec/unit/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
+++ b/spec/unit/puppet_x/puppetlabs/scheduled_task/trigger_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 require 'spec_helper'
 require 'puppet_x/puppetlabs/scheduled_task/trigger'
 


### PR DESCRIPTION
## Summary
Fixing CI failure due to rubocop

## Additional Context
- [x] New version released in rubocop-rspec ([v2.24.0](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.24.0)) caused regression in linting.
```
Split RSpec/FilePath into RSpec/SpecFilePathSuffix and RSpec/SpecFilePathFormat. RSpec/FilePath cop is enabled by default, the two new cops are pending and need to be enabled explicitly. (@ydah)
Add RSpec/MetadataStyle and RSpec/EmptyMetadata cops.
```

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)