### PR TITLE
Add delay properties to triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,43 @@ scheduled_task { 'Disk Cleanup On Restart':
 ~~~
 * Note: Duration properties like `minutes_duration` and `minutes_interval` must have `compatibility => 2` or higher specified for `boot` triggers. Windows does not support those options at the "Windows XP or Windows Server 2003 computer" compatibility level which is the default when compatibility is left unspecified.
 
+You can also add a random delay to your scheduled tasks to prevent multiple tasks from starting at exactly the same time:
+
+~~~puppet
+scheduled_task { 'Disk Cleanup with Random Delay':
+  ensure        => 'present',
+  compatibility => 2,
+  command       => "$::system32\\WindowsPowerShell\\v1.0\\powershell.exe",
+  arguments     => '-File "C:\\Scripts\\Clear-DiskSpace.ps1"',
+  enabled       => 'true',
+  trigger       => [{
+    'schedule'     => 'daily',
+    'start_time'   => '07:00',
+    'random_delay' => 'PT30M'  # Adds a random delay of up to 30 minutes
+  }],
+  user          => 'system',
+}
+~~~
+* Note: The `random_delay` property requires `compatibility => 2` or higher and is only supported for schedule-based triggers (daily, weekly, monthly, and once).
+
+For event-based triggers like boot or logon, you can specify a delay to wait before running the task:
+
+~~~puppet
+scheduled_task { 'Disk Cleanup After Boot with Delay':
+  ensure        => 'present',
+  compatibility => 2,
+  command       => "$::system32\\WindowsPowerShell\\v1.0\\powershell.exe",
+  arguments     => '-File "C:\\Scripts\\Clear-DiskSpace.ps1"',
+  enabled       => 'true',
+  trigger       => [{
+    'schedule'  => 'boot',
+    'delay'     => 'PT5M'  # Starts the task 5 minutes after boot
+  }],
+  user          => 'system',
+}
+~~~
+* Note: The `delay` property requires `compatibility => 2` or higher and is only supported for event-based triggers (boot, logon, registration, event, and session state change).
+
 If you want a task to run at logon, use the `logon` trigger:
 
 ~~~puppet
@@ -289,6 +326,16 @@ For all triggers:
   You should format dates as YYYY-MM-DD, although other date formats may work (under the hood, this uses Date.parse).
 * `minutes_interval` — The repeat interval in minutes.
 * `minutes_duration` — The duration in minutes, needs to be greater than the minutes_interval.
+* `random_delay` --- A random delay to add to the start time of the trigger.
+  The format for this is a duration string (ISO8601) like PT15M for 15 minutes or
+  P1DT3H24M for 1 day, 3 hours and 24 minutes. This property requires a
+  compatibility of 2 or higher and is only supported for schedule-based triggers
+  (daily, weekly, monthly, and once).
+* `delay` --- A fixed delay to add to the start time of event-based triggers.
+  The format for this is a duration string (ISO8601) like PT15M for 15 minutes or
+  P1DT3H24M for 1 day, 3 hours and 24 minutes. This property requires a
+  compatibility of 2 or higher and is only supported for event-based triggers
+  (boot, logon, registration, event, and session state change).
 * For daily triggers:
   * `every` — How often the task should run, as a number of days.
     Defaults to 1.
@@ -349,5 +396,5 @@ This codebase is licensed under the Apache2.0 licensing, however due to the natu
 <a id="development"></a>
 ## Development
 
-Puppet modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can't access the huge number of platforms and myriad hardware, software, and deployment configurations that Puppet is intended to serve, therefore want to keep it as easy as possible to contribute changes so that our modules work in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things. 
+Puppet modules on the Puppet Forge are open projects, and community contributions are essential for keeping them great. We can't access the huge number of platforms and myriad hardware, software, and deployment configurations that Puppet is intended to serve, therefore want to keep it as easy as possible to contribute changes so that our modules work in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
 If you would like to contribute to this module, please follow the rules in the [CONTRIBUTING.md](https://github.com/puppetlabs/puppetlabs-scheduled_task/blob/main/CONTRIBUTING.md). For more information, see our [module contribution guide.](https://puppet.com/docs/puppet/latest/contributing.html).

--- a/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
+++ b/lib/puppet/provider/scheduled_task/taskscheduler_api2.rb
@@ -123,6 +123,19 @@ Puppet::Type.type(:scheduled_task).provide(:taskscheduler_api2) do
     desired_triggers = value.is_a?(Array) ? value : [value]
     current_triggers = trigger.is_a?(Array) ? trigger : [trigger]
 
+    # Add debugging
+    Puppet.debug("Setting triggers: #{desired_triggers.inspect}")
+    
+    # Check for random_delay with incompatible task
+    if resource[:compatibility] < 2 && desired_triggers.any? { |t| t.is_a?(Hash) && t['random_delay'] && !t['random_delay'].empty? }
+      Puppet.warning("The 'random_delay' property requires compatibility level 2 or higher. Current compatibility level is #{resource[:compatibility]}.")
+    end
+
+    # Check for delay with incompatible task
+    if resource[:compatibility] < 2 && desired_triggers.any? { |t| t.is_a?(Hash) && t['delay'] && !t['delay'].empty? }
+      Puppet.warning("The 'delay' property requires compatibility level 2 or higher. Current compatibility level is #{resource[:compatibility]}.")
+    end
+
     extra_triggers = []
     desired_to_search = desired_triggers.dup
     current_triggers.each do |current|

--- a/lib/puppet/type/scheduled_task.rb
+++ b/lib/puppet/type/scheduled_task.rb
@@ -155,6 +155,16 @@ Puppet::Type.newtype(:scheduled_task) do
           * `disable_time_zone_synchronization` --- Whether or not to disable the
             `synchronise across time zones` function. Due to difficulties with the
             api this is non idempotent. Defaults to false
+          * `random_delay` --- A random delay to add to the start time of the trigger.
+            The format for this string is a duration string like PT15M for 15 minutes or
+            P1DT3H24M for 1 day, 3 hours and 24 minutes. This property requires a
+            compatibility of 2 or higher and is only supported for schedule-based triggers
+            (daily, weekly, monthly, and once).
+          * `delay` --- A fixed delay to add to the start time of event-based triggers.
+            The format for this string is a duration string like PT15M for 15 minutes or
+            P1DT3H24M for 1 day, 3 hours and 24 minutes. This property requires a
+            compatibility of 2 or higher and is only supported for event-based triggers
+            (boot, logon, registration, event, and session state change).
       * For `daily` triggers:
           * `every` --- How often the task should run, as a number of days. Defaults
             to 1. ("2" means every other day, "3" means every three days, etc.)

--- a/lib/puppet_x/puppet_labs/scheduled_task/task.rb
+++ b/lib/puppet_x/puppet_labs/scheduled_task/task.rb
@@ -471,6 +471,7 @@ module PuppetX::PuppetLabs::ScheduledTask
     # Appends a new trigger for the currently active task.
     #
     def append_trigger(manifest_hash)
+      Puppet.debug("Task.append_trigger called with: #{manifest_hash.inspect}")
       Trigger::V2.append_trigger(@definition, manifest_hash)
     end
 

--- a/spec/unit/puppet_x/puppet_labs/scheduled_task/trigger_spec.rb
+++ b/spec/unit/puppet_x/puppet_labs/scheduled_task/trigger_spec.rb
@@ -160,6 +160,28 @@ describe PuppetX::PuppetLabs::ScheduledTask::Trigger do
         end
       end
 
+      describe 'when validating delay and random_delay properties' do
+        it 'accepts valid ISO8601 duration format for delay' do
+          logon_manifest = { 'schedule' => 'logon', 'delay' => 'PT15M' }
+          expect { manifest.class.canonicalize_and_validate(logon_manifest) }.not_to raise_error
+        end
+
+        it 'rejects invalid format for delay' do
+          logon_manifest = { 'schedule' => 'logon', 'delay' => 'invalid_format' }
+          expect { manifest.class.canonicalize_and_validate(logon_manifest) }.to raise_error(ArgumentError, /Invalid delay value/)
+        end
+
+        it 'accepts valid ISO8601 duration format for random_delay' do
+          daily_manifest = { 'schedule' => 'daily', 'start_time' => '01:00', 'random_delay' => 'PT15M' }
+          expect { manifest.class.canonicalize_and_validate(daily_manifest) }.not_to raise_error
+        end
+
+        it 'rejects invalid format for random_delay' do
+          daily_manifest = { 'schedule' => 'daily', 'start_time' => '01:00', 'random_delay' => 'invalid_format' }
+          expect { manifest.class.canonicalize_and_validate(daily_manifest) }.to raise_error(ArgumentError, /Invalid random_delay value/)
+        end
+      end
+
       it 'canonicalizes `start_time` to %H:%M' do
         manifest_hash = MINIMAL_MANIFEST_HASH.merge('start_time' => '2:03 pm')
         expected = MINIMAL_MANIFEST_HASH.merge('start_time' => '14:03')


### PR DESCRIPTION
## Summary
This PR adds delay properties to scheduled task triggers. This feature is currently missing from the module, but adding delays to triggers is a useful function, supported from compatibility version 2 onwards.

## Additional Context
- The logic is aware of schedule-based vs event-based triggers, and adds the required delay property for each style
- Warnings are logged if the delay is added to a trigger that doesn't support it or if the compatibility mode is below 2 (which doesn't support trigger delays)
- The format of the delay input is [ISO 8601](https://www.w3.org/TR/xmlschema-2/#duration), as per the [MS implementation](https://learn.microsoft.com/en-us/windows/win32/taskschd/taskschedulerschema-delay-boottriggertype-element)
- Debug messages have been added to provide detailed trigger information

Example of newly supported schedule configuration where the boot trigger will be delayed by 1 minute and where the daily and weekly trigger will have a random delay of 30 minutes:
```
  scheduled_task { 'Run Powershell Script':
    ensure        => 'present',
    compatibility => 4,
    provider      => 'taskscheduler_api2',
    enabled       => true,
    command       => 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe',
    arguments     => 'C:\Temp\myscript.ps1',
    trigger       => [
      {
        schedule => 'boot',
        delay    => 'PT1M',
      },
      {
        schedule         => 'weekly',
        day_of_week      => 'sat',
        start_time       => '04:15',
        random_delay     => 'PT30M',
        minutes_interval => 60,
        minutes_duration => 720,
      },
      {
        schedule     => 'daily',
        start_time   => '22:00',
        random_delay => 'PT30M',
        every        => 1,
      },
    ],
    user => 'system',
  }
```

## Related Issues (if any)
This PR additionally resolves issue [#259 - Add support for delay option for boot trigger](https://github.com/puppetlabs/puppetlabs-scheduled_task/issues/259)


## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. This has been running in an environment of over 600 machines for a month